### PR TITLE
feat: expand metadata returned by search call, allow filter on collection name

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,7 +6,7 @@ build-and-push-server:
     KO_DOCKER_REPO: registry.gitlab.com/testifysec/judge-platform/archivist/archivist
   stage: build
   image:
-    name: registry.gitlab.com/testifysec/docker-images/ko:0.9.3
+    name: registry.gitlab.com/testifysec/docker-images/ko:0.11.2
     entrypoint: [""]
   script:
     - ko auth login -u ${CI_REGISTRY_USER} -p ${CI_REGISTRY_PASSWORD} ${CI_REGISTRY}
@@ -17,7 +17,7 @@ build-and-push-client:
     KO_DOCKER_REPO: registry.gitlab.com/testifysec/judge-platform/archivist/archivistctl
   stage: build
   image:
-    name: registry.gitlab.com/testifysec/docker-images/ko:0.9.3
+    name: registry.gitlab.com/testifysec/docker-images/ko:0.11.2
     entrypoint: [""]
   script:
     - ko auth login -u ${CI_REGISTRY_USER} -p ${CI_REGISTRY_PASSWORD} ${CI_REGISTRY}

--- a/cmd/archivistctl/cmd/retrieve.go
+++ b/cmd/archivistctl/cmd/retrieve.go
@@ -1,0 +1,59 @@
+package cmd
+
+import (
+	"context"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/testifysec/archivist-api/pkg/api/archivist"
+)
+
+var (
+	outFile string
+
+	retrieveCmd = &cobra.Command{
+		Use:          "retrieve",
+		Short:        "Retrieves a dsse envelope by it's gitoid from archivist",
+		SilenceUsage: true,
+		Args:         cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			conn, err := newConn(archivistUrl)
+			if err != nil {
+				return err
+			}
+
+			var out io.Writer = os.Stdout
+			if len(outFile) > 0 {
+				file, err := os.Create(outFile)
+				defer file.Close()
+				if err != nil {
+					return err
+				}
+
+				out = file
+			}
+
+			return retrieveEnvelope(cmd.Context(), archivist.NewCollectorClient(conn), args[0], out)
+		},
+	}
+)
+
+func init() {
+	rootCmd.AddCommand(retrieveCmd)
+	retrieveCmd.Flags().StringVarP(&outFile, "out", "o", "", "File to write the envelope out to. Defaults to stdout")
+}
+
+func retrieveEnvelope(ctx context.Context, client archivist.CollectorClient, gitoid string, out io.Writer) error {
+	resp, err := client.Get(ctx, &archivist.GetRequest{Gitoid: gitoid})
+	if err != nil {
+		return err
+	}
+
+	if _, err := io.Copy(out, strings.NewReader(resp.Object)); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cmd/archivistctl/cmd/root.go
+++ b/cmd/archivistctl/cmd/root.go
@@ -1,0 +1,28 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+var (
+	archivistUrl string
+
+	rootCmd = &cobra.Command{
+		Use:   "archivistctl",
+		Short: "A utility to interact with an archivist server",
+	}
+)
+
+func init() {
+	rootCmd.PersistentFlags().StringVarP(&archivistUrl, "archivisturl", "u", "localhost:8080", "url of the archivist instance")
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func newConn(url string) (*grpc.ClientConn, error) {
+	return grpc.Dial(url, grpc.WithTransportCredentials(insecure.NewCredentials()))
+}

--- a/cmd/archivistctl/cmd/search.go
+++ b/cmd/archivistctl/cmd/search.go
@@ -1,0 +1,92 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/testifysec/archivist-api/pkg/api/archivist"
+)
+
+var (
+	collectionName string
+
+	searchCmd = &cobra.Command{
+		Use:          "search",
+		Short:        "Searches the archivist instance for an attestation matching a query",
+		SilenceUsage: true,
+		Long: `Searches the archivist instance for an envelope with a specified subject digest.
+Optionally a collection name can be provided to further constrain results.
+
+Digests are expected to be in the form algorithm:digest, for instance: sha256:456c0c9a7c05e2a7f84c139bbacedbe3e8e88f9c`,
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 1 {
+				return errors.New("expected exactly 1 argument")
+			}
+
+			if _, _, err := validateDigestString(args[0]); err != nil {
+				return err
+			}
+
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			conn, err := newConn(archivistUrl)
+			defer conn.Close()
+			if err != nil {
+				return nil
+			}
+
+			algo, digest, err := validateDigestString(args[0])
+			if err != nil {
+				return err
+			}
+
+			return searchArchivist(cmd.Context(), archivist.NewArchivistClient(conn), algo, digest, collectionName)
+		},
+	}
+)
+
+func init() {
+	rootCmd.AddCommand(searchCmd)
+	searchCmd.Flags().StringVarP(&collectionName, "collectionname", "n", "", "Only envelopes containing an attestation collection with the provided name will be returned.")
+}
+
+func validateDigestString(ds string) (algo, digest string, err error) {
+	algo, digest, found := strings.Cut(ds, ":")
+	if !found {
+		return "", "", errors.New("invalid digest string. expected algorithm:digest")
+	}
+
+	return algo, digest, nil
+}
+
+func searchArchivist(ctx context.Context, client archivist.ArchivistClient, algo, digest, collName string) error {
+	req := &archivist.GetBySubjectDigestRequest{Algorithm: algo, Value: digest, CollectionName: collName}
+	stream, err := client.GetBySubjectDigest(ctx, req)
+	if err != nil {
+		return err
+	}
+
+	for {
+		resp, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+
+		if err != nil {
+			return err
+		}
+
+		printResponse(resp)
+	}
+
+	return nil
+}
+
+func printResponse(resp *archivist.GetBySubjectDigestResponse) {
+	fmt.Printf("Gitoid: %s\nCollection name: %s\nAttestations: %s\n\n", resp.GetGitoid(), resp.GetCollectionName(), strings.Join(resp.GetAttestations(), ", "))
+}

--- a/cmd/archivistctl/cmd/store.go
+++ b/cmd/archivistctl/cmd/store.go
@@ -1,0 +1,63 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/testifysec/archivist-api/pkg/api/archivist"
+	"github.com/testifysec/go-witness/dsse"
+)
+
+var (
+	storeCmd = &cobra.Command{
+		Use:          "store",
+		Short:        "stores an attestation on the archivist server",
+		SilenceUsage: true,
+		Args:         cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			conn, err := newConn(archivistUrl)
+			defer conn.Close()
+			if err != nil {
+				return err
+			}
+
+			file, err := os.Open(args[0])
+			defer file.Close()
+			if err != nil {
+				return err
+			}
+
+			return storeAttestation(cmd.Context(), archivist.NewCollectorClient(conn), file)
+		},
+	}
+)
+
+func init() {
+	rootCmd.AddCommand(storeCmd)
+}
+
+func storeAttestation(ctx context.Context, client archivist.CollectorClient, envelope io.Reader) error {
+	objBytes, err := io.ReadAll(envelope)
+	if err != nil {
+		return err
+	}
+
+	obj := &dsse.Envelope{}
+	if err := json.Unmarshal(objBytes, &obj); err != nil {
+		return err
+	}
+
+	if len(obj.Payload) == 0 || obj.PayloadType == "" || len(obj.Signatures) == 0 {
+		return fmt.Errorf("obj is not DSSE %d %d %d", len(obj.Payload), len(obj.PayloadType), len(obj.Signatures))
+	}
+
+	if _, err := client.Store(ctx, &archivist.StoreRequest{Object: string(objBytes)}); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cmd/archivistctl/main.go
+++ b/cmd/archivistctl/main.go
@@ -15,71 +15,13 @@
 package main
 
 import (
-	"context"
-	"encoding/json"
-	"fmt"
-	"github.com/testifysec/go-witness/dsse"
-	"io/ioutil"
 	"os"
 
-	"github.com/testifysec/archivist-api/pkg/api/archivist"
-
-	"github.com/sirupsen/logrus"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
+	"github.com/testifysec/archivist/cmd/archivistctl/cmd"
 )
 
 func main() {
-	if len(os.Args) != 2 {
-		logrus.Fatalln("error")
-	}
-
-	file, err := ioutil.ReadFile(os.Args[1])
-	if err != nil {
-		logrus.Fatalf("unable to read file %+v", err)
-	}
-
-	var opts []grpc.DialOption
-	opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
-	conn, err := grpc.Dial("127.0.0.1:8080", opts...)
-	if err != nil {
-		logrus.Fatalf("unable to grpc dial: %+v", err)
-	}
-	defer func() {
-		err := conn.Close()
-		if err != nil {
-			logrus.Errorf("unable to close connection: %+v", err)
-		}
-	}()
-
-	archivistClient := archivist.NewArchivistClient(conn)
-	collectorClient := archivist.NewCollectorClient(conn)
-
-	// check if valid
-
-	obj := &dsse.Envelope{}
-	err = json.Unmarshal(file, obj)
-	if err != nil {
-		logrus.Fatalln("could not unmarshal input: ", err)
-	}
-
-	if len(obj.Payload) == 0 || obj.PayloadType == "" || len(obj.Signatures) == 0 {
-		logrus.Fatalf("obj is not DSSE %d %d %d", len(obj.Payload), len(obj.PayloadType), len(obj.Signatures))
-	}
-
-	_, err = collectorClient.Store(context.Background(), &archivist.StoreRequest{
-		Object: string(file),
-	})
-	if err != nil {
-		logrus.Errorf("unable to store object: %+v", err)
-	}
-
-	resp, err := archivistClient.GetBySubjectDigest(context.Background(), &archivist.GetBySubjectDigestRequest{Algorithm: "sha256", Value: "3ff8d62302fe86d3f2d637843c696ab4d065f9e1cc873121806cf9467e546e4f"})
-	if err != nil {
-		logrus.Fatalf("unable to retrieve object: %+v", err)
-	}
-
-	for i, v := range resp.GetObject() {
-		fmt.Printf("%d: %s\n", i, v)
+	if err := cmd.Execute(); err != nil {
+		os.Exit(1)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -13,8 +13,9 @@ require (
 	github.com/minio/minio-go v6.0.14+incompatible
 	github.com/networkservicemesh/sdk v1.3.0
 	github.com/sirupsen/logrus v1.8.1
+	github.com/spf13/cobra v1.4.0
 	github.com/spiffe/go-spiffe/v2 v2.0.0
-	github.com/testifysec/archivist-api v0.0.0-20220603060816-12e25ceccbf1
+	github.com/testifysec/archivist-api v0.0.0-20220707182002-b803369e93a4
 	github.com/testifysec/go-witness v0.1.11
 	google.golang.org/grpc v1.46.0
 	google.golang.org/protobuf v1.28.0
@@ -36,10 +37,12 @@ require (
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0 // indirect
 	github.com/hashicorp/hcl/v2 v2.10.0 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/go-wordwrap v0.0.0-20150314170334-ad45545899c7 // indirect
 	github.com/networkservicemesh/api v1.3.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/zclconf/go-cty v1.10.0 // indirect
 	github.com/zeebo/errs v1.2.2 // indirect
 	go.opencensus.io v0.23.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -45,6 +45,7 @@ github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20211001041855-01bcc9b48dfe/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
+github.com/cpuguy83/go-md2man/v2 v2.0.1/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -156,6 +157,7 @@ github.com/hashicorp/hcl/v2 v2.10.0 h1:1S1UnuhDGlv3gRFV4+0EdwB+znNP5HmcGbIqwnSCB
 github.com/hashicorp/hcl/v2 v2.10.0/go.mod h1:FwWsfWEjyV/CMj8s/gqAuiviY72rJ1/oayI9WftqcKg=
 github.com/hashicorp/raft v1.3.6/go.mod h1:4Ak7FSPnuvmb0GV6vgIAJ4vYT4bek9bb6Q+7HVbyzqM=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
+github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jcmturner/aescts/v2 v2.0.0/go.mod h1:AiaICIRyfYg35RUkr8yESTqvSy7csK90qZ5xfvvsoNs=
 github.com/jcmturner/dnsutils/v2 v2.0.0/go.mod h1:b0TnjGOvI/n42bZa+hmXL+kFJZsFT7G4t3HTlQ184QM=
@@ -187,7 +189,6 @@ github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVc
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.10/go.mod h1:qgIWMr58cqv1PHHyhnkY9lrL7etaEgOFcMEpPG5Rm84=
 github.com/mattn/go-runewidth v0.0.0-20181025052659-b20a3daf6a39/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
-github.com/mattn/go-runewidth v0.0.13 h1:lTGmDsbAYt5DmK6OnoV7EuIF1wEIFAcxld6ypU4OSgU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/minio/highwayhash v1.0.2/go.mod h1:BQskDq+xkJ12lmlUUi7U0M5Swg3EWR+dLTk+kldvVxY=
 github.com/minio/minio-go v6.0.14+incompatible h1:fnV+GD28LeqdN6vT2XdGKW8Qe/IfjJDswNVuni6km9o=
@@ -213,7 +214,6 @@ github.com/networkservicemesh/sdk v1.3.0/go.mod h1:lThahTYTHh1JWlAPrtfmVsRLK7vFJ
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/olekukonko/tablewriter v0.0.1/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
-github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
 github.com/onsi/ginkgo v1.16.4/go.mod h1:dX+/inL/fNMqNlz0e9LfyB9TswhZpCVdJM/Z6Vvnwo0=
@@ -244,9 +244,9 @@ github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/rabbitmq/amqp091-go v1.1.0/go.mod h1:ogQDLSOACsLPsIq0NpbtiifNZi2YOz0VTJ0kHRghqbM=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
-github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
@@ -256,9 +256,11 @@ github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/cobra v0.0.0-20181021141114-fe5e611709b0/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/cobra v1.4.0 h1:y+wJpx64xcgO1V+RcnwW0LEHxTKRi2ZDPSBjWnrg88Q=
+github.com/spf13/cobra v1.4.0/go.mod h1:Wo4iy3BUC+X2Fybo0PDqwJIv3dNRiZLHQymsfxlB84g=
 github.com/spf13/pflag v0.0.0-20181024212040-082b515c9490/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.2/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spiffe/go-spiffe/v2 v2.0.0 h1:y6N7BZAxgaFZYELyrIdxSMm2e2tWpzgQewUts9h1hfM=
 github.com/spiffe/go-spiffe/v2 v2.0.0/go.mod h1:TEfgrEcyFhuSuvqohJt6IxENUNeHfndWCCV1EX7UaVk=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -270,8 +272,8 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
-github.com/testifysec/archivist-api v0.0.0-20220603060816-12e25ceccbf1 h1:I1hggIy2JI6+jJ+gqIY3xyl77XBJeFfjXJMMCQ4MIq8=
-github.com/testifysec/archivist-api v0.0.0-20220603060816-12e25ceccbf1/go.mod h1:HWpNFd8qFXCoU8gEF/xiuG10ni9EBFhPcpAFTcWDAmc=
+github.com/testifysec/archivist-api v0.0.0-20220707182002-b803369e93a4 h1:osCfJqj8ohaHzxY7Ssn1XMUvUiLAUUSY8F0jYqgvUTA=
+github.com/testifysec/archivist-api v0.0.0-20220707182002-b803369e93a4/go.mod h1:HWpNFd8qFXCoU8gEF/xiuG10ni9EBFhPcpAFTcWDAmc=
 github.com/testifysec/go-witness v0.1.11 h1:CK5I7g7yu+ObXraYN96KHZu9VmLLs4vKEvfcEi4E35E=
 github.com/testifysec/go-witness v0.1.11/go.mod h1:EGTMK84vV6/7kiCbJYonESTvaeOW2eMJVHh3mW/EWYU=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
@@ -447,7 +449,6 @@ golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roY
 golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.5/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
-golang.org/x/tools v0.1.9-0.20211216111533-8d383106f7e7 h1:M1gcVrIb2lSn2FIL19DG0+/b8nNVKJ7W7b4WcAGZAYM=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/internal/objectstorage/blobstore/minio.go
+++ b/internal/objectstorage/blobstore/minio.go
@@ -37,14 +37,8 @@ type Indexer interface {
 	PutBlob(idx string, obj []byte) error
 }
 
-type UnifiedStorage interface {
-	archivist.CollectorServer
-	archivist.StorageServer
-}
-
 type attestationBlobStore struct {
 	archivist.UnimplementedCollectorServer
-	archivist.UnimplementedStorageServer
 
 	client   *minio.Client
 	bucket   string
@@ -109,7 +103,7 @@ func (store *attestationBlobStore) PutBlob(idx string, obj []byte) error {
 }
 
 // NewMinioClient returns a reader/writer for storing/retrieving attestations
-func NewMinioClient(ctx context.Context, endpoint, accessKeyId, secretAccessKeyId, bucketName string, useSSL bool) (UnifiedStorage, <-chan error, error) {
+func NewMinioClient(ctx context.Context, endpoint, accessKeyId, secretAccessKeyId, bucketName string, useSSL bool) (archivist.CollectorServer, <-chan error, error) {
 	errCh := make(chan error)
 	go func() {
 		<-ctx.Done()

--- a/internal/objectstorage/filestore/file.go
+++ b/internal/objectstorage/filestore/file.go
@@ -15,19 +15,13 @@ import (
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
-type UnifiedStorage interface {
-	archivist.CollectorServer
-	archivist.StorageServer
-}
-
 type store struct {
 	archivist.UnimplementedCollectorServer
-	archivist.UnimplementedStorageServer
 
 	prefix string
 }
 
-func NewServer(ctx context.Context, directory string, address string) (UnifiedStorage, <-chan error, error) {
+func NewServer(ctx context.Context, directory string, address string) (archivist.CollectorServer, <-chan error, error) {
 	errCh := make(chan error)
 	go func() {
 


### PR DESCRIPTION
…tion name

Adds the collection name and the identifiers of any attestations
contained within the collection to the response from GetBySubjectDigest.

Adds a parameter to limit results by a collection's name.

Adds more options to archivistctl to interact with archivist.

Some code re-org to split up metadata stores from object stores, and
moves the object store calls out of the mysqlstore.

Signed-off-by: Mikhail Swift <mikhail@testifysec.com>

Will require https://github.com/testifysec/archivist-api/pull/1 and a go mod update before merge