### PR TITLE
bug: fix zero bytes before message

### DIFF
--- a/internal/objectstorage/blobstore/minio.go
+++ b/internal/objectstorage/blobstore/minio.go
@@ -58,7 +58,7 @@ func (store *attestationBlobStore) GetRef(obj []byte) (string, error) {
 func (store *attestationBlobStore) GetBlob(idx string) ([]byte, error) {
 	opt := minio.GetObjectOptions{}
 	chunkSize := 8 * 1024
-	buf := make([]byte, chunkSize)
+	buf := make([]byte, 0, chunkSize)
 	outBuf := bytes.NewBuffer(buf)
 
 	obj, err := store.client.GetObject(store.bucket, idx, opt)


### PR DESCRIPTION
When retrieving attestations from archivist currently a bunch of zero
bytes are prepended before the message payload.  This causes extra data
to be transmitted as well as payloads being unable to be parsed as json
without the manual removal of these zero bytes.

The buffer used when reading from minio was being initialized with both
size and capacity equal to 8\*1024, which causes this issue.  By
initialize it with size 0 and capacity 8\*1024 the buffer will start
filling at index 0.

Signed-off-by: Mikhail Swift <mikhail@testifysec.com>