### PR TITLE
Feat/object streaming

### DIFF
--- a/cmd/archivistctl/cmd/store.go
+++ b/cmd/archivistctl/cmd/store.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/testifysec/archivist-api/pkg/api/archivist"
+	"github.com/testifysec/archivist/internal/server"
 	"github.com/testifysec/go-witness/dsse"
 )
 
@@ -17,7 +18,7 @@ var (
 		Use:          "store",
 		Short:        "stores an attestation on the archivist server",
 		SilenceUsage: true,
-		Args:         cobra.ExactArgs(1),
+		Args:         cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			conn, err := newConn(archivistUrl)
 			defer conn.Close()
@@ -25,13 +26,15 @@ var (
 				return err
 			}
 
-			file, err := os.Open(args[0])
-			defer file.Close()
-			if err != nil {
-				return err
+			for _, filePath := range args {
+				if gitoid, err := storeAttestationByPath(cmd.Context(), archivist.NewCollectorClient(conn), filePath); err != nil {
+					return fmt.Errorf("failed to store %s: %w", filePath, err)
+				} else {
+					fmt.Printf("%s stored with gitoid %s\n", filePath, gitoid)
+				}
 			}
 
-			return storeAttestation(cmd.Context(), archivist.NewCollectorClient(conn), file)
+			return nil
 		},
 	}
 )
@@ -40,24 +43,53 @@ func init() {
 	rootCmd.AddCommand(storeCmd)
 }
 
-func storeAttestation(ctx context.Context, client archivist.CollectorClient, envelope io.Reader) error {
+func storeAttestationByPath(ctx context.Context, client archivist.CollectorClient, path string) (string, error) {
+	file, err := os.Open(path)
+	defer file.Close()
+	if err != nil {
+		return "", err
+	}
+
+	return storeAttestation(ctx, client, file)
+}
+
+func storeAttestation(ctx context.Context, client archivist.CollectorClient, envelope io.Reader) (string, error) {
 	objBytes, err := io.ReadAll(envelope)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	obj := &dsse.Envelope{}
 	if err := json.Unmarshal(objBytes, &obj); err != nil {
-		return err
+		return "", err
 	}
 
 	if len(obj.Payload) == 0 || obj.PayloadType == "" || len(obj.Signatures) == 0 {
-		return fmt.Errorf("obj is not DSSE %d %d %d", len(obj.Payload), len(obj.PayloadType), len(obj.Signatures))
+		return "", fmt.Errorf("obj is not DSSE %d %d %d", len(obj.Payload), len(obj.PayloadType), len(obj.Signatures))
 	}
 
-	if _, err := client.Store(ctx, &archivist.StoreRequest{Object: string(objBytes)}); err != nil {
-		return err
+	stream, err := client.Store(ctx)
+	if err != nil {
+		return "", err
 	}
 
-	return nil
+	chunk := &archivist.Chunk{}
+	for curr := 0; curr < len(objBytes); curr += server.ChunkSize {
+		if curr+server.ChunkSize > len(objBytes) {
+			chunk.Chunk = objBytes[curr:]
+		} else {
+			chunk.Chunk = objBytes[curr : curr+server.ChunkSize]
+		}
+
+		if err := stream.Send(chunk); err != nil {
+			return "", err
+		}
+	}
+
+	resp, err := stream.CloseAndRecv()
+	if err != nil {
+		return "", err
+	}
+
+	return resp.GetGitoid(), nil
 }

--- a/go.mod
+++ b/go.mod
@@ -15,10 +15,9 @@ require (
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.4.0
 	github.com/spiffe/go-spiffe/v2 v2.0.0
-	github.com/testifysec/archivist-api v0.0.0-20220707182002-b803369e93a4
+	github.com/testifysec/archivist-api v0.0.0-20220719182705-980989009502
 	github.com/testifysec/go-witness v0.1.11
 	google.golang.org/grpc v1.46.0
-	google.golang.org/protobuf v1.28.0
 )
 
 require (
@@ -65,5 +64,6 @@ require (
 	golang.org/x/sys v0.0.0-20220412211240-33da011f77ad // indirect
 	golang.org/x/text v0.3.7 // indirect
 	google.golang.org/genproto v0.0.0-20220222213610-43724f9ea8cf // indirect
+	google.golang.org/protobuf v1.28.0 // indirect
 	gopkg.in/square/go-jose.v2 v2.6.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -272,8 +272,8 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
-github.com/testifysec/archivist-api v0.0.0-20220707182002-b803369e93a4 h1:osCfJqj8ohaHzxY7Ssn1XMUvUiLAUUSY8F0jYqgvUTA=
-github.com/testifysec/archivist-api v0.0.0-20220707182002-b803369e93a4/go.mod h1:HWpNFd8qFXCoU8gEF/xiuG10ni9EBFhPcpAFTcWDAmc=
+github.com/testifysec/archivist-api v0.0.0-20220719182705-980989009502 h1:9y2qBW9yrxDa5R+mHr4uHmPIOIkyjhCD5XzNtynHVMU=
+github.com/testifysec/archivist-api v0.0.0-20220719182705-980989009502/go.mod h1:HWpNFd8qFXCoU8gEF/xiuG10ni9EBFhPcpAFTcWDAmc=
 github.com/testifysec/go-witness v0.1.11 h1:CK5I7g7yu+ObXraYN96KHZu9VmLLs4vKEvfcEi4E35E=
 github.com/testifysec/go-witness v0.1.11/go.mod h1:EGTMK84vV6/7kiCbJYonESTvaeOW2eMJVHh3mW/EWYU=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=

--- a/internal/objectstorage/blobstore/minio.go
+++ b/internal/objectstorage/blobstore/minio.go
@@ -20,77 +20,19 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/git-bom/gitbom-go"
 	"github.com/minio/minio-go"
 	"github.com/minio/minio-go/pkg/credentials"
-	"github.com/sirupsen/logrus"
 	"github.com/testifysec/archivist-api/pkg/api/archivist"
-	"google.golang.org/protobuf/types/known/emptypb"
 )
 
-// Indexer calculates the index reference for an input blob,
-// and gets/puts blobs at that index in and out of the backing
-// blob storage.
-type Indexer interface {
-	GetRef(obj []byte) (string, error)
-	GetBlob(idx string) ([]byte, error)
-	PutBlob(idx string, obj []byte) error
-}
-
-type attestationBlobStore struct {
-	archivist.UnimplementedCollectorServer
-
+type Store struct {
 	client   *minio.Client
 	bucket   string
 	location string
 }
 
-// GetRef calculates the index reference for a given object
-func (store *attestationBlobStore) GetRef(obj []byte) (string, error) {
-	gb := gitbom.NewSha256GitBom()
-	if err := gb.AddReference(obj, nil); err != nil {
-		return "", err
-	}
-	return gb.Identity(), nil
-}
-
-// GetBlob retrieves an attesation from the backend store
-func (store *attestationBlobStore) GetBlob(idx string) ([]byte, error) {
-	opt := minio.GetObjectOptions{}
-	chunkSize := 8 * 1024
-	buf := make([]byte, 0, chunkSize)
-	outBuf := bytes.NewBuffer(buf)
-
-	obj, err := store.client.GetObject(store.bucket, idx, opt)
-	if err != nil {
-		return buf, err
-	}
-
-	var n int64
-	for {
-		_ = opt.SetRange(n, n+int64(chunkSize)-1)
-		readBytes, err := outBuf.ReadFrom(obj)
-		if err == nil {
-			return outBuf.Bytes(), nil
-		}
-		if err != nil {
-			if err == io.EOF {
-				_, err = outBuf.ReadFrom(bytes.NewReader(buf))
-				break
-			}
-		}
-
-		n += readBytes
-		_, err = outBuf.ReadFrom(bytes.NewReader(buf))
-		if err != nil {
-			return buf, fmt.Errorf("failed to chunk blob: %v", err)
-		}
-	}
-	return []byte{}, fmt.Errorf("failed to read out object: %v", err)
-}
-
 // PutBlob stores the attestation blob into the backend store
-func (store *attestationBlobStore) PutBlob(idx string, obj []byte) error {
+func (store *Store) PutBlob(idx string, obj []byte) error {
 	opt := minio.PutObjectOptions{}
 	size := int64(len(obj))
 	n, err := store.client.PutObject(store.bucket, idx, bytes.NewReader(obj), size, opt)
@@ -102,8 +44,8 @@ func (store *attestationBlobStore) PutBlob(idx string, obj []byte) error {
 	return nil
 }
 
-// NewMinioClient returns a reader/writer for storing/retrieving attestations
-func NewMinioClient(ctx context.Context, endpoint, accessKeyId, secretAccessKeyId, bucketName string, useSSL bool) (archivist.CollectorServer, <-chan error, error) {
+// New returns a reader/writer for storing/retrieving attestations
+func New(ctx context.Context, endpoint, accessKeyId, secretAccessKeyId, bucketName string, useSSL bool) (*Store, <-chan error, error) {
 	errCh := make(chan error)
 	go func() {
 		<-ctx.Done()
@@ -128,36 +70,17 @@ func NewMinioClient(ctx context.Context, endpoint, accessKeyId, secretAccessKeyI
 		return nil, errCh, err
 	}
 
-	return &attestationBlobStore{
+	return &Store{
 		client:   c,
 		location: loc,
 		bucket:   bucketName,
 	}, errCh, nil
 }
 
-func (s *attestationBlobStore) Get(ctx context.Context, req *archivist.GetRequest) (*archivist.GetResponse, error) {
-	obj, err := s.GetBlob(req.GetGitoid())
-	if err != nil {
-		logrus.WithContext(ctx).Errorf("failed to retrieve object: %+v", err)
-		return nil, err
-	}
-
-	return &archivist.GetResponse{
-		Gitoid: req.GetGitoid(),
-		Object: string(obj),
-	}, nil
+func (s *Store) Get(ctx context.Context, req *archivist.GetRequest) (io.ReadCloser, error) {
+	return s.client.GetObjectWithContext(ctx, s.bucket, req.GetGitoid(), minio.GetObjectOptions{})
 }
 
-func (s *attestationBlobStore) Store(ctx context.Context, req *archivist.StoreRequest) (*emptypb.Empty, error) {
-	idx, err := s.GetRef([]byte(req.GetObject()))
-	if err != nil {
-		logrus.WithContext(ctx).Errorf("gitbom tag generation failed: %+v", err)
-		return nil, err
-	}
-
-	if err := s.PutBlob(idx, []byte(req.GetObject())); err != nil {
-		logrus.WithContext(ctx).Errorf("failed to store object: %+v", err)
-	}
-
-	return &emptypb.Empty{}, nil
+func (s *Store) Store(ctx context.Context, gitoid string, payload []byte) error {
+	return s.PutBlob(gitoid, payload)
 }

--- a/internal/objectstorage/filestore/file.go
+++ b/internal/objectstorage/filestore/file.go
@@ -2,65 +2,38 @@ package filestore
 
 import (
 	"context"
-	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
+	"os"
 	"path/filepath"
 
-	"github.com/git-bom/gitbom-go"
 	"github.com/gorilla/handlers"
-	"github.com/sirupsen/logrus"
 	"github.com/testifysec/archivist-api/pkg/api/archivist"
-	"google.golang.org/protobuf/types/known/emptypb"
 )
 
-type store struct {
-	archivist.UnimplementedCollectorServer
-
+type Store struct {
 	prefix string
 }
 
-func NewServer(ctx context.Context, directory string, address string) (archivist.CollectorServer, <-chan error, error) {
+func New(ctx context.Context, directory string, address string) (*Store, <-chan error, error) {
 	errCh := make(chan error)
 	go func() {
-
 		server := handlers.CompressHandler(http.FileServer(http.Dir(directory)))
 		log.Fatalln(http.ListenAndServe(address, server))
-
 		<-ctx.Done()
 		close(errCh)
 	}()
 
-	return &store{
+	return &Store{
 		prefix: directory,
 	}, errCh, nil
 }
 
-func (s *store) Get(ctx context.Context, request *archivist.GetRequest) (*archivist.GetResponse, error) {
-	res, err := ioutil.ReadFile(filepath.Join(s.prefix, request.GetGitoid()))
-	if err != nil {
-		logrus.WithContext(ctx).Errorf("failed to retrieve object: %+v", err)
-		return nil, err
-	}
-	return &archivist.GetResponse{
-		Gitoid: request.GetGitoid(),
-		Object: string(res),
-	}, nil
+func (s *Store) Get(ctx context.Context, request *archivist.GetRequest) (io.ReadCloser, error) {
+	return os.Open(filepath.Join(s.prefix, request.GetGitoid()+".json"))
 }
 
-func (s *store) Store(ctx context.Context, request *archivist.StoreRequest) (*emptypb.Empty, error) {
-	// TODO refactor this to use common code
-	gb := gitbom.NewSha256GitBom()
-	if err := gb.AddReference([]byte(request.Object), nil); err != nil {
-		logrus.WithContext(ctx).Errorf("gitbom tag generation failed: %+v", err)
-		return nil, err
-	}
-
-	fmt.Printf("Writing: %s/%s\n", s.prefix, gb.Identity())
-	err := ioutil.WriteFile(filepath.Join(s.prefix, gb.Identity()+".json"), []byte(request.Object), 0644)
-	if err != nil {
-		return nil, err
-	}
-	return &emptypb.Empty{}, nil
+func (s *Store) Store(ctx context.Context, gitoid string, payload []byte) error {
+	return os.WriteFile(filepath.Join(s.prefix, gitoid+".json"), payload, 0644)
 }


### PR DESCRIPTION
Stream attestations to and from the collection service.  grpc has a
default message size of 4MB and (from my limited research) isn't suited
well for large single messages.  Instead opting to stream many messages
is preferred.

Consensus seems to hover around 16-64k message sizes: https://github.com/grpc/grpc.github.io/issues/371

Requires https://github.com/testifysec/archivist-api/pull/3 and a go.mod update before merge