### PR TITLE
bug: signature column cannot handle all signatures

### DIFF
--- a/ent/attestation_query.go
+++ b/ent/attestation_query.go
@@ -301,7 +301,6 @@ func (aq *AttestationQuery) WithAttestationCollection(opts ...func(*AttestationC
 //		GroupBy(attestation.FieldType).
 //		Aggregate(ent.Count()).
 //		Scan(ctx, &v)
-//
 func (aq *AttestationQuery) GroupBy(field string, fields ...string) *AttestationGroupBy {
 	grbuild := &AttestationGroupBy{config: aq.config}
 	grbuild.fields = append([]string{field}, fields...)
@@ -328,7 +327,6 @@ func (aq *AttestationQuery) GroupBy(field string, fields ...string) *Attestation
 //	client.Attestation.Query().
 //		Select(attestation.FieldType).
 //		Scan(ctx, &v)
-//
 func (aq *AttestationQuery) Select(fields ...string) *AttestationSelect {
 	aq.fields = append(aq.fields, fields...)
 	selbuild := &AttestationSelect{AttestationQuery: aq}

--- a/ent/attestationcollection_query.go
+++ b/ent/attestationcollection_query.go
@@ -338,7 +338,6 @@ func (acq *AttestationCollectionQuery) WithStatement(opts ...func(*StatementQuer
 //		GroupBy(attestationcollection.FieldName).
 //		Aggregate(ent.Count()).
 //		Scan(ctx, &v)
-//
 func (acq *AttestationCollectionQuery) GroupBy(field string, fields ...string) *AttestationCollectionGroupBy {
 	grbuild := &AttestationCollectionGroupBy{config: acq.config}
 	grbuild.fields = append([]string{field}, fields...)
@@ -365,7 +364,6 @@ func (acq *AttestationCollectionQuery) GroupBy(field string, fields ...string) *
 //	client.AttestationCollection.Query().
 //		Select(attestationcollection.FieldName).
 //		Scan(ctx, &v)
-//
 func (acq *AttestationCollectionQuery) Select(fields ...string) *AttestationCollectionSelect {
 	acq.fields = append(acq.fields, fields...)
 	selbuild := &AttestationCollectionSelect{AttestationCollectionQuery: acq}

--- a/ent/client.go
+++ b/ent/client.go
@@ -144,7 +144,6 @@ func (c *Client) BeginTx(ctx context.Context, opts *sql.TxOptions) (*Tx, error) 
 //		Attestation.
 //		Query().
 //		Count(ctx)
-//
 func (c *Client) Debug() *Client {
 	if c.debug {
 		return c

--- a/ent/dsse_query.go
+++ b/ent/dsse_query.go
@@ -374,7 +374,6 @@ func (dq *DsseQuery) WithPayloadDigests(opts ...func(*PayloadDigestQuery)) *Dsse
 //		GroupBy(dsse.FieldGitoidSha256).
 //		Aggregate(ent.Count()).
 //		Scan(ctx, &v)
-//
 func (dq *DsseQuery) GroupBy(field string, fields ...string) *DsseGroupBy {
 	grbuild := &DsseGroupBy{config: dq.config}
 	grbuild.fields = append([]string{field}, fields...)
@@ -401,7 +400,6 @@ func (dq *DsseQuery) GroupBy(field string, fields ...string) *DsseGroupBy {
 //	client.Dsse.Query().
 //		Select(dsse.FieldGitoidSha256).
 //		Scan(ctx, &v)
-//
 func (dq *DsseQuery) Select(fields ...string) *DsseSelect {
 	dq.fields = append(dq.fields, fields...)
 	selbuild := &DsseSelect{DsseQuery: dq}

--- a/ent/ent.go
+++ b/ent/ent.go
@@ -95,7 +95,6 @@ type AggregateFunc func(*sql.Selector) string
 //	GroupBy(field1, field2).
 //	Aggregate(ent.As(ent.Sum(field1), "sum_field1"), (ent.As(ent.Sum(field2), "sum_field2")).
 //	Scan(ctx, &v)
-//
 func As(fn AggregateFunc, end string) AggregateFunc {
 	return func(s *sql.Selector) string {
 		return sql.As(fn(s), end)

--- a/ent/gql_node.go
+++ b/ent/gql_node.go
@@ -426,9 +426,8 @@ func (c *Client) newNodeOpts(opts []NodeOption) *nodeOptions {
 // Noder returns a Node by its id. If the NodeType was not provided, it will
 // be derived from the id value according to the universal-id configuration.
 //
-//		c.Noder(ctx, id)
-//		c.Noder(ctx, id, ent.WithNodeType(typeResolver))
-//
+//	c.Noder(ctx, id)
+//	c.Noder(ctx, id, ent.WithNodeType(typeResolver))
 func (c *Client) Noder(ctx context.Context, id int, opts ...NodeOption) (_ Noder, err error) {
 	defer func() {
 		if IsNotFound(err) {

--- a/ent/hook/hook.go
+++ b/ent/hook/hook.go
@@ -208,7 +208,6 @@ func HasFields(field string, fields ...string) Condition {
 // If executes the given hook under condition.
 //
 //	hook.If(ComputeAverage, And(HasFields(...), HasAddedFields(...)))
-//
 func If(hk ent.Hook, cond Condition) ent.Hook {
 	return func(next ent.Mutator) ent.Mutator {
 		return ent.MutateFunc(func(ctx context.Context, m ent.Mutation) (ent.Value, error) {
@@ -223,7 +222,6 @@ func If(hk ent.Hook, cond Condition) ent.Hook {
 // On executes the given hook only for the given operation.
 //
 //	hook.On(Log, ent.Delete|ent.Create)
-//
 func On(hk ent.Hook, op ent.Op) ent.Hook {
 	return If(hk, HasOp(op))
 }
@@ -231,7 +229,6 @@ func On(hk ent.Hook, op ent.Op) ent.Hook {
 // Unless skips the given hook only for the given operation.
 //
 //	hook.Unless(Log, ent.Update|ent.UpdateOne)
-//
 func Unless(hk ent.Hook, op ent.Op) ent.Hook {
 	return If(hk, Not(HasOp(op)))
 }
@@ -252,7 +249,6 @@ func FixedError(err error) ent.Hook {
 //			Reject(ent.Delete|ent.Update),
 //		}
 //	}
-//
 func Reject(op ent.Op) ent.Hook {
 	hk := FixedError(fmt.Errorf("%s operation is not allowed", op))
 	return On(hk, op)

--- a/ent/migrate/migrate.go
+++ b/ent/migrate/migrate.go
@@ -54,10 +54,9 @@ func (s *Schema) Create(ctx context.Context, opts ...schema.MigrateOption) error
 
 // WriteTo writes the schema changes to w instead of running them against the database.
 //
-// 	if err := client.Schema.WriteTo(context.Background(), os.Stdout); err != nil {
+//	if err := client.Schema.WriteTo(context.Background(), os.Stdout); err != nil {
 //		log.Fatal(err)
-// 	}
-//
+//	}
 func (s *Schema) WriteTo(ctx context.Context, w io.Writer, opts ...schema.MigrateOption) error {
 	drv := &schema.WriteDriver{
 		Writer: w,

--- a/ent/migrate/schema.go
+++ b/ent/migrate/schema.go
@@ -94,7 +94,7 @@ var (
 	SignaturesColumns = []*schema.Column{
 		{Name: "id", Type: field.TypeInt, Increment: true},
 		{Name: "key_id", Type: field.TypeString},
-		{Name: "signature", Type: field.TypeString, Unique: true},
+		{Name: "signature", Type: field.TypeString, SchemaType: map[string]string{"mysql": "text"}},
 		{Name: "dsse_signatures", Type: field.TypeInt, Nullable: true},
 	}
 	// SignaturesTable holds the schema information for the "signatures" table.

--- a/ent/payloaddigest_query.go
+++ b/ent/payloaddigest_query.go
@@ -301,7 +301,6 @@ func (pdq *PayloadDigestQuery) WithDsse(opts ...func(*DsseQuery)) *PayloadDigest
 //		GroupBy(payloaddigest.FieldAlgorithm).
 //		Aggregate(ent.Count()).
 //		Scan(ctx, &v)
-//
 func (pdq *PayloadDigestQuery) GroupBy(field string, fields ...string) *PayloadDigestGroupBy {
 	grbuild := &PayloadDigestGroupBy{config: pdq.config}
 	grbuild.fields = append([]string{field}, fields...)
@@ -328,7 +327,6 @@ func (pdq *PayloadDigestQuery) GroupBy(field string, fields ...string) *PayloadD
 //	client.PayloadDigest.Query().
 //		Select(payloaddigest.FieldAlgorithm).
 //		Scan(ctx, &v)
-//
 func (pdq *PayloadDigestQuery) Select(fields ...string) *PayloadDigestSelect {
 	pdq.fields = append(pdq.fields, fields...)
 	selbuild := &PayloadDigestSelect{PayloadDigestQuery: pdq}

--- a/ent/schema/signature.go
+++ b/ent/schema/signature.go
@@ -2,6 +2,7 @@ package schema
 
 import (
 	"entgo.io/ent"
+	"entgo.io/ent/dialect"
 	"entgo.io/ent/schema/edge"
 	"entgo.io/ent/schema/field"
 )
@@ -15,7 +16,7 @@ type Signature struct {
 func (Signature) Fields() []ent.Field {
 	return []ent.Field{
 		field.String("key_id").NotEmpty(),
-		field.String("signature").Unique().NotEmpty(),
+		field.String("signature").NotEmpty().SchemaType(map[string]string{dialect.MySQL: "text"}),
 	}
 }
 

--- a/ent/signature_query.go
+++ b/ent/signature_query.go
@@ -301,7 +301,6 @@ func (sq *SignatureQuery) WithDsse(opts ...func(*DsseQuery)) *SignatureQuery {
 //		GroupBy(signature.FieldKeyID).
 //		Aggregate(ent.Count()).
 //		Scan(ctx, &v)
-//
 func (sq *SignatureQuery) GroupBy(field string, fields ...string) *SignatureGroupBy {
 	grbuild := &SignatureGroupBy{config: sq.config}
 	grbuild.fields = append([]string{field}, fields...)
@@ -328,7 +327,6 @@ func (sq *SignatureQuery) GroupBy(field string, fields ...string) *SignatureGrou
 //	client.Signature.Query().
 //		Select(signature.FieldKeyID).
 //		Scan(ctx, &v)
-//
 func (sq *SignatureQuery) Select(fields ...string) *SignatureSelect {
 	sq.fields = append(sq.fields, fields...)
 	selbuild := &SignatureSelect{SignatureQuery: sq}

--- a/ent/statement_query.go
+++ b/ent/statement_query.go
@@ -373,7 +373,6 @@ func (sq *StatementQuery) WithDsse(opts ...func(*DsseQuery)) *StatementQuery {
 //		GroupBy(statement.FieldPredicate).
 //		Aggregate(ent.Count()).
 //		Scan(ctx, &v)
-//
 func (sq *StatementQuery) GroupBy(field string, fields ...string) *StatementGroupBy {
 	grbuild := &StatementGroupBy{config: sq.config}
 	grbuild.fields = append([]string{field}, fields...)
@@ -400,7 +399,6 @@ func (sq *StatementQuery) GroupBy(field string, fields ...string) *StatementGrou
 //	client.Statement.Query().
 //		Select(statement.FieldPredicate).
 //		Scan(ctx, &v)
-//
 func (sq *StatementQuery) Select(fields ...string) *StatementSelect {
 	sq.fields = append(sq.fields, fields...)
 	selbuild := &StatementSelect{StatementQuery: sq}

--- a/ent/subject_query.go
+++ b/ent/subject_query.go
@@ -338,7 +338,6 @@ func (sq *SubjectQuery) WithStatement(opts ...func(*StatementQuery)) *SubjectQue
 //		GroupBy(subject.FieldName).
 //		Aggregate(ent.Count()).
 //		Scan(ctx, &v)
-//
 func (sq *SubjectQuery) GroupBy(field string, fields ...string) *SubjectGroupBy {
 	grbuild := &SubjectGroupBy{config: sq.config}
 	grbuild.fields = append([]string{field}, fields...)
@@ -365,7 +364,6 @@ func (sq *SubjectQuery) GroupBy(field string, fields ...string) *SubjectGroupBy 
 //	client.Subject.Query().
 //		Select(subject.FieldName).
 //		Scan(ctx, &v)
-//
 func (sq *SubjectQuery) Select(fields ...string) *SubjectSelect {
 	sq.fields = append(sq.fields, fields...)
 	selbuild := &SubjectSelect{SubjectQuery: sq}

--- a/ent/subjectdigest_query.go
+++ b/ent/subjectdigest_query.go
@@ -301,7 +301,6 @@ func (sdq *SubjectDigestQuery) WithSubject(opts ...func(*SubjectQuery)) *Subject
 //		GroupBy(subjectdigest.FieldAlgorithm).
 //		Aggregate(ent.Count()).
 //		Scan(ctx, &v)
-//
 func (sdq *SubjectDigestQuery) GroupBy(field string, fields ...string) *SubjectDigestGroupBy {
 	grbuild := &SubjectDigestGroupBy{config: sdq.config}
 	grbuild.fields = append([]string{field}, fields...)
@@ -328,7 +327,6 @@ func (sdq *SubjectDigestQuery) GroupBy(field string, fields ...string) *SubjectD
 //	client.SubjectDigest.Query().
 //		Select(subjectdigest.FieldAlgorithm).
 //		Scan(ctx, &v)
-//
 func (sdq *SubjectDigestQuery) Select(fields ...string) *SubjectDigestSelect {
 	sdq.fields = append(sdq.fields, fields...)
 	selbuild := &SubjectDigestSelect{SubjectDigestQuery: sdq}


### PR DESCRIPTION
By default ent generates a mysql column of type `varchar(255)` for string types. This poses a problem for RSA-PSS signatures as these signatures have lengths equal to the size of the RSA key.

For instance an RSA key with length of 4096bits will generate a signature with length 4096bits, or 512 bytes. This obviously will not fit in a `varchar(255)` column.

This PR changes the signature column to use a MySQL `text` column type which can handle strings of up to 65,535 bytes.

Signed-off-by: Mikhail Swift <mikhail@testifysec.com>