### PR TITLE
Upgrade to go 1.21

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [ 1.19.x ]
+        go-version: [ 1.21.x ]
         os: [ ubuntu-latest ]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/verify-license.yml
+++ b/.github/workflows/verify-license.yml
@@ -26,7 +26,7 @@ jobs:
         - uses: actions/checkout@v2
         - uses: actions/setup-go@v2
           with:
-            go-version: '1.19.x'
+            go-version: '1.21.x'
         - name: Install addlicense
           run: go install github.com/google/addlicense@latest
         - name: Check license headers

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.20.5-alpine AS build
+FROM golang:1.21.3-alpine AS build
 WORKDIR /src
 RUN apk update && apk add --no-cache file git
 ENV GOMODCACHE /root/.cache/gocache

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/testifysec/archivista
 
-go 1.19
+go 1.21
 
 require (
 	ariga.io/sqlcomment v0.0.0-20211020114721-6bb67a62a61a

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,7 @@ github.com/99designs/gqlgen v0.17.5-0.20220428154617-9250f9ac1f90 h1:nGGP+sUJ6D3
 github.com/99designs/gqlgen v0.17.5-0.20220428154617-9250f9ac1f90/go.mod h1:SNpLVzaF37rRLSAXtu8FKVp5I4zycneMmFX6NT4XGSU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/DATA-DOG/go-sqlmock v1.5.0 h1:Shsta01QNfFxHCfpW6YH2STWB0MudeXXEWMr20OEh60=
+github.com/DATA-DOG/go-sqlmock v1.5.0/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/agext/levenshtein v1.2.1 h1:QmvMAjj2aEICytGiWzmxoE0x2KZvE0fvmqMOfy2tjT8=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=
@@ -111,9 +112,11 @@ github.com/kevinmbeaulieu/eq-go v1.0.0/go.mod h1:G3S8ajA56gKBZm4UB9AOyoOS37JO3ro
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
+github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/lib/pq v1.10.7 h1:p7ZhMD+KsSRozJr34udlUrhboJwWAgCg34+/ZZNvZZw=
@@ -123,6 +126,7 @@ github.com/matryer/moq v0.2.7/go.mod h1:kITsx543GOENm48TUAQyJ9+SAvFSr7iGQXPoth/V
 github.com/mattn/go-colorable v0.1.12/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/mattn/go-sqlite3 v1.14.16 h1:yOQRA0RpS5PFz/oikGwBEqvAWhWg5ufRz4ETLjwpU1Y=
+github.com/mattn/go-sqlite3 v1.14.16/go.mod h1:2eHXhiwb8IkHr+BDWZGa96P6+rkvnG63S2DGjv9HUNg=
 github.com/minio/minio-go v6.0.14+incompatible h1:fnV+GD28LeqdN6vT2XdGKW8Qe/IfjJDswNVuni6km9o=
 github.com/minio/minio-go v6.0.14+incompatible/go.mod h1:7guKYtitv8dktvNUGrhzmNlA5wrAABTQXCoesZdFQO8=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
@@ -136,9 +140,11 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/rogpeppe/go-internal v1.8.0 h1:FCbCCtXNOY3UtUuHUYaghJg4y7Fd14rXifAYUAtL9R8=
+github.com/rogpeppe/go-internal v1.8.0/go.mod h1:WmiCO8CzOY8rg0OYDC4/i/2WRWAB6poM+XZ2dLUbcbE=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/sergi/go-diff v1.3.1 h1:xkr+Oxo4BOQKmkn/B9eMK0g5Kg/983T9DqqPHwYqD+8=
+github.com/sergi/go-diff v1.3.1/go.mod h1:aMJSSKb2lpPvRNec0+w3fl7LP9IOFzdc9Pa4NFbPK1I=
 github.com/sirupsen/logrus v1.9.0 h1:trlNQbNUG3OdDrDil03MCb1H2o9nJ1x4/5LYw7byDE0=
 github.com/sirupsen/logrus v1.9.0/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/spf13/cobra v1.7.0 h1:hyqWnYt1ZQShIddO5kBpj3vu05/++x6tJ6dg8EC572I=


### PR DESCRIPTION
- Upgrade to go 1.21 to avoid Vulnerabilities in the go standard library.

<details>
<summary> govulncheck  in go 1.20</summary>

  ```  
  govulncheck ./... Scanning your code and 359 packages across 56 dependent modules for known vulnerabilities.

Vulnerability #1: GO-2023-2102
    HTTP/2 rapid reset can cause excessive work in net/http
  More info: https://pkg.go.dev/vuln/GO-2023-2102
  Standard library
    Found in: net/http@go1.20.1
    Fixed in: net/http@go1.21.3
    Example traces found:
      #1: internal/objectstorage/filestore/file.go:36:34: filestore.New calls http.ListenAndServe
      #2: cmd/archivista/main.go:144:23: archivista.main calls http.Serve

Vulnerability #2: GO-2023-2043
    Improper handling of special tags within script contexts in html/template
  More info: https://pkg.go.dev/vuln/GO-2023-2043
  Standard library
    Found in: html/template@go1.20.1
    Fixed in: html/template@go1.21.1
    Example traces found:
      #1: cmd/archivista/main.go:144:23: archivista.main calls http.Serve, which eventually calls template.Template.Execute

Vulnerability #3: GO-2023-2041
    Improper handling of HTML-like comments in script contexts in html/template
  More info: https://pkg.go.dev/vuln/GO-2023-2041
  Standard library
    Found in: html/template@go1.20.1
    Fixed in: html/template@go1.21.1
    Example traces found:
      #1: cmd/archivista/main.go:144:23: archivista.main calls http.Serve, which eventually calls template.Template.Execute

Vulnerability #4: GO-2023-1987
    Large RSA keys can cause high CPU usage in crypto/tls
  More info: https://pkg.go.dev/vuln/GO-2023-1987
  Standard library
    Found in: crypto/tls@go1.20.1
    Fixed in: crypto/tls@go1.21rc4
    Example traces found:
      #1: ent/tx.go:226:19: ent.txDriver.Exec calls sql.Conn.Exec, which eventually calls tls.Conn.Handshake
      #2: cmd/archivista/main.go:144:23: archivista.main calls http.Serve, which eventually calls tls.Conn.HandshakeContext
      #3: internal/server/server.go:136:22: server.Server.GetHandler calls io.Copy, which eventually calls tls.Conn.Read
      #4: /Users/naveen/go/pkg/mod/entgo.io/contrib@v0.4.5/entgql/pagination.go:66:16: entgql.OrderDirection.MarshalGQL calls io.WriteString, which calls tls.Conn.Write
      #5: internal/objectstorage/blobstore/minio.go:62:31: blobstore.New calls minio.Client.BucketExists, which eventually calls tls.Dialer.DialContext

Vulnerability #5: GO-2023-1878
    Insufficient sanitization of Host header in net/http
  More info: https://pkg.go.dev/vuln/GO-2023-1878
  Standard library
    Found in: net/http@go1.20.1
    Fixed in: net/http@go1.20.6
    Example traces found:
      #1: internal/objectstorage/blobstore/minio.go:62:31: blobstore.New calls minio.Client.BucketExists, which eventually calls http.Client.Do
      #2: internal/objectstorage/blobstore/minio.go:62:31: blobstore.New calls minio.Client.BucketExists, which eventually calls http.Transport.CloseIdleConnections
      #3: internal/objectstorage/blobstore/minio.go:62:31: blobstore.New calls minio.Client.BucketExists, which eventually calls http.Transport.RoundTrip

Vulnerability #6: GO-2023-1840
    Unsafe behavior in setuid/setgid binaries in runtime
  More info: https://pkg.go.dev/vuln/GO-2023-1840
  Standard library
    Found in: runtime@go1.20.1
    Fixed in: runtime@go1.20.5
    Example traces found:
      #1: internal/objectstorage/filestore/file.go:36:14: filestore.New calls log.Fatalln, which eventually calls runtime.Caller
      #2: internal/server/server.go:138:16: server.Server.GetHandler calls http.response.WriteHeader, which eventually calls runtime.Callers
      #3: internal/server/server.go:138:16: server.Server.GetHandler calls http.response.WriteHeader, which eventually calls runtime.CallersFrames
      #4: internal/server/server.go:138:16: server.Server.GetHandler calls http.response.WriteHeader, which eventually calls runtime.Frames.Next
      #5: ent/gql_node.go:472:11: ent.tables.Load calls sync.Once.Do, which eventually calls runtime.Func.Name
      #6: ent/gql_node.go:472:11: ent.tables.Load calls sync.Once.Do, which eventually calls runtime.FuncForPC
      #7: ent/gql_collection.go:941:46: ent.unmarshalArgs calls graphql.UnmarshalInputFromContext, which eventually calls runtime.GC
      #8: internal/server/server.go:96:26: server.Server.StoreHandler calls json.Encoder.Encode, which eventually calls runtime.GOMAXPROCS
      #9: internal/metadatastorage/sqlstore/client.go:76:34: sqlstore.NewEntClient calls mysql.ParseDSN, which eventually calls runtime.GOROOT
      #10: internal/objectstorage/filestore/file.go:51:21: filestore.Store.Store calls os.WriteFile, which eventually calls runtime.KeepAlive
      #11: internal/server/server.go:135:2: server.Server.GetHandler calls os.File.Close, which eventually calls runtime.SetFinalizer
      #12: ent/gql_node.go:472:11: ent.tables.Load calls sync.Once.Do, which eventually calls runtime.Stack
      #13: internal/server/server.go:91:26: server.Server.StoreHandler calls runtime.TypeAssertionError.Error
      #14: ent/gql_node.go:472:11: ent.tables.Load calls sync.Once.Do, which eventually calls runtime.Version
      #15: internal/metadatastorage/sqlstore/client.go:20:2: sqlstore.init calls time.init, which eventually calls runtime.efaceOf
      #16: internal/server/server.go:91:26: server.Server.StoreHandler calls runtime.errorAddressString.Error
      #17: internal/server/server.go:91:26: server.Server.StoreHandler calls runtime.errorString.Error
      #18: internal/metadatastorage/sqlstore/client.go:20:2: sqlstore.init calls time.init, which eventually calls runtime.findfunc
      #19: internal/metadatastorage/sqlstore/client.go:20:2: sqlstore.init calls time.init, which eventually calls runtime.float64frombits
      #20: internal/metadatastorage/sqlstore/client.go:20:2: sqlstore.init calls time.init, which eventually calls runtime.forcegchelper
      #21: internal/metadatastorage/sqlstore/client.go:20:2: sqlstore.init calls time.init, which eventually calls runtime.funcMaxSPDelta
      #22: internal/metadatastorage/sqlstore/client.go:20:2: sqlstore.init calls time.init, which eventually calls runtime.lockInit
      #23: internal/server/server.go:91:26: server.Server.StoreHandler calls runtime.plainError.Error
      #24: internal/metadatastorage/sqlstore/client.go:20:2: sqlstore.init calls time.init, which eventually calls runtime.throw

Vulnerability #7: GO-2023-1753
    Improper handling of empty HTML attributes in html/template
  More info: https://pkg.go.dev/vuln/GO-2023-1753
  Standard library
    Found in: html/template@go1.20.1
    Fixed in: html/template@go1.20.4
    Example traces found:
      #1: cmd/archivista/main.go:144:23: archivista.main calls http.Serve, which eventually calls template.Template.Execute

Vulnerability #8: GO-2023-1752
    Improper handling of JavaScript whitespace in html/template
  More info: https://pkg.go.dev/vuln/GO-2023-1752
  Standard library
    Found in: html/template@go1.20.1
    Fixed in: html/template@go1.20.4
    Example traces found:
      #1: cmd/archivista/main.go:144:23: archivista.main calls http.Serve, which eventually calls template.Template.Execute

Vulnerability #9: GO-2023-1751
    Improper sanitization of CSS values in html/template
  More info: https://pkg.go.dev/vuln/GO-2023-1751
  Standard library
    Found in: html/template@go1.20.1
    Fixed in: html/template@go1.20.4
    Example traces found:
      #1: cmd/archivista/main.go:144:23: archivista.main calls http.Serve, which eventually calls template.Template.Execute

Vulnerability #10: GO-2023-1705
    Excessive resource consumption in net/http, net/textproto and mime/multipart
  More info: https://pkg.go.dev/vuln/GO-2023-1705
  Standard library
    Found in: net/textproto@go1.20.1
    Fixed in: net/textproto@go1.20.3
    Example traces found:
      #1: internal/server/server.go:56:28: server.Server.Store calls io.ReadAll, which eventually calls textproto.Reader.ReadMIMEHeader
      #2: cmd/archivista/main.go:144:23: archivista.main calls http.Serve, which eventually calls multipart.Reader.ReadForm

Vulnerability #11: GO-2023-1704
    Excessive memory allocation in net/http and net/textproto
  More info: https://pkg.go.dev/vuln/GO-2023-1704
  Standard library
    Found in: net/textproto@go1.20.1
    Fixed in: net/textproto@go1.20.3
    Example traces found:
      #1: internal/server/server.go:56:28: server.Server.Store calls io.ReadAll, which eventually calls textproto.Reader.ReadMIMEHeader

Vulnerability #12: GO-2023-1703
    Backticks not treated as string delimiters in html/template
  More info: https://pkg.go.dev/vuln/GO-2023-1703
  Standard library
    Found in: html/template@go1.20.1
    Fixed in: html/template@go1.20.3
    Example traces found:
      #1: cmd/archivista/main.go:144:23: archivista.main calls http.Serve, which eventually calls template.Template.Execute

Vulnerability #13: GO-2023-1702
    Infinite loop in parsing in go/scanner
  More info: https://pkg.go.dev/vuln/GO-2023-1702
  Standard library
    Found in: go/scanner@go1.20.1
    Fixed in: go/scanner@go1.20.3
    Example traces found:
      #1: ent/schema/dsse.go:18:2: schema.init calls entgql.init, which eventually calls scanner.Scanner.Scan

Vulnerability #14: GO-2023-1621
    Incorrect calculation on P256 curves in crypto/internal/nistec
  More info: https://pkg.go.dev/vuln/GO-2023-1621
  Standard library
    Found in: crypto/internal/nistec@go1.20.1
    Fixed in: crypto/internal/nistec@go1.20.2
    Example traces found:
      #1: internal/server/server.go:136:22: server.Server.GetHandler calls io.Copy, which eventually calls nistec.P256OrdInverse
      #2: internal/server/server.go:136:22: server.Server.GetHandler calls io.Copy, which eventually calls nistec.P256Point.ScalarBaseMult
      #3: internal/server/server.go:136:22: server.Server.GetHandler calls io.Copy, which eventually calls nistec.P256Point.ScalarMult

Your code is affected by 14 vulnerabilities from the Go standard library.
  ```

  </details>