### PR TITLE
Fixed the jq failure for test.sh

### DIFF
--- a/test/test.sh
+++ b/test/test.sh
@@ -38,7 +38,7 @@ waitForArchivista() {
   echo "Waiting for archivista to be ready..."
   for attempt in $(seq 1 6); do
     sleep 10
-    local archivistastate=$(docker compose -f "$DIR/../compose.yml" ps archivista --format json | jq -r '.State')
+    local archivistastate=$(docker compose -f "$DIR/../compose.yml" ps archivista --format json | jq -r '.[0].State')
     if [ "$archivistastate" == "running" ]; then
       break
     fi


### PR DESCRIPTION
- Ensure that the jq command correctly accesses the first element of the array
- Wait for archivista to be ready before executing the script

[test/test.sh]
- Change the jq command to access the first element of the array
- Wait for archivista to be ready before proceeding with the script