### PR TITLE
Auto-update pre-commit hooks PR

### DIFF
--- a/.github/workflows/update-pre-commit-hooks.yml
+++ b/.github/workflows/update-pre-commit-hooks.yml
@@ -1,0 +1,53 @@
+# Copyright 2023 The Archivista Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This workflow uses actions that are not certified by GitHub. They are provided
+# by a third-party and are governed by separate terms of service, privacy
+# policy, and support documentation.
+
+name: Update pre-commit hooks
+on:
+  workflow_dispatch:
+  schedule:
+    # Run at 8:00 AM every day
+    - cron: "0 8 * * *"
+jobs:
+  update-pre-commit-hooks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      - uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236
+        with:
+          python-version: "3.11"
+      - name: Install prerequisites
+        run: |
+          pip install pre-commit
+      - name: Update pre-commit hooks
+        run: |
+          pre-commit autoupdate
+      - name: Check for pre-commit config file changes
+        id: git_diff
+        run: |
+          echo "GIT_DIFF=$(git diff --exit-code 1> /dev/null; echo $?)" >> $GITHUB_OUTPUT
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "build: Update pre-commit hooks"
+          branch: "archivista-bot/update-pre-commit-hooks"
+          delete-branch: true
+          title: "build: Update pre-commit hooks"
+          body: >
+            The following PR updates the pre-commit hooks (`.pre-commit-config.yaml` file) using `pre-commit autoupdate`.
+          labels: report, automated pr, pre-commit


### PR DESCRIPTION
Using pre-commit can be very helpful for new contributors, but it can also bring some difficulties.

Sometimes, a contributor will have a different version of the hook, which is not part of his PR. We should keep it updated upstream to avoid different checks due to mismatched versions.

This commit adds a GHA workflow to submit updates (like dependabot)