### PR TITLE
fix: license-check workflow Archivist > Archivista

### DIFF
--- a/.github/workflows/verify-licence.yml
+++ b/.github/workflows/verify-licence.yml
@@ -40,4 +40,4 @@ jobs:
         - name: Check license headers
           run: |
             set -e
-            addlicense --check -l apache -c 'The Archivist Contributors' -v ./
+            addlicense --check -l apache -c 'The Archivista Contributors' -v ./


### PR DESCRIPTION
fix typo in license-check workflow "Archivist" to "Archivista"