### PR TITLE
fix: unecessary build while running `make run-dev`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,6 @@ all: help
 
 run-dev:  ## Run the dev server
 	@echo "Running dev server. It will refresh automatically when you change code."
-	@docker build -t archivista:dev .
 	@docker compose -f compose-dev.yml up --remove-orphans
 
 


### PR DESCRIPTION
It will build the container using the `compose-dev.yml` by default.

If found it while working on database migrations