### PR TITLE
test: Minor change to increase the coverage

### DIFF
--- a/cmd/archivistactl/cmd/root_test.go
+++ b/cmd/archivistactl/cmd/root_test.go
@@ -35,7 +35,7 @@ func (ut *UTRootSuite) Test_Root() {
 	rootCmd.SetOut(output)
 	rootCmd.SetErr(output)
 	rootCmd.SetArgs([]string{"help"})
-	err := rootCmd.Execute()
+	err := Execute()
 	if err != nil {
 		ut.FailNow(err.Error())
 	}


### PR DESCRIPTION
Running `rootCmd.Execute` is the same as`Execute`, but for coverage it has an increase as it is a function declared in `cmd`.