### PR TITLE
test: consolidate tests and add code coverage

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -40,28 +40,19 @@ jobs:
           attestations: "github"
           command: go vet ./...
 
-    test:
+    tests:
         needs: [fmt, static_analysis]
         uses: ./.github/workflows/witness.yml
         with:
             pull_request: ${{ github.event_name == 'pull_request' }}
-            step: "test"
-            attestations: "github"
-            command: go test -v -coverprofile=profile.cov -covermode=atomic ./...
-
-    e2e-tests:
-        needs: test
-        uses: ./.github/workflows/witness.yml
-        with:
-            pull_request: ${{ github.event_name == 'pull_request' }}
-            step: "e2e"
+            step: "tests"
             attestations: "github"
             command: |
               make clean
               make test
 
     release:
-        needs: e2e-tests
+        needs: tests
         permissions:
             id-token: write
             contents: write

--- a/.github/workflows/witness.yml
+++ b/.github/workflows/witness.yml
@@ -48,5 +48,9 @@ jobs:
               step: ${{ inputs.step }}
               attestations: ${{ inputs.attestations }}
               command: /bin/sh -c "${{ inputs.command }}"
+
           - if: ${{ inputs.pull_request == true }}
             run: ${{ inputs.command }}
+
+          - if: ${{ inputs.step == 'tests' }}
+            uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d


### PR DESCRIPTION
This commit consolidates the `tests` and `e2e` tests in one. The command `make tests` already run all the tests (unit and e2e).

This commit also includes in witness.yml the action to save the cover.out to be used later by the pipeline to download the cover.out and upload to the CodeCov.