### PR TITLE
fix: consistency protection storing attestations

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -64,16 +64,16 @@ func (s *Server) Store(ctx context.Context, r io.Reader) (api.StoreResponse, err
 		return api.StoreResponse{}, err
 	}
 
-	if err := s.metadataStore.Store(ctx, gid.String(), payload); err != nil {
-		logrus.Errorf("received error from metadata store: %+v", err)
-		return api.StoreResponse{}, err
-	}
-
 	if s.objectStore != nil {
 		if err := s.objectStore.Store(ctx, gid.String(), payload); err != nil {
 			logrus.Errorf("received error from object store: %+v", err)
 			return api.StoreResponse{}, err
 		}
+	}
+
+	if err := s.metadataStore.Store(ctx, gid.String(), payload); err != nil {
+		logrus.Errorf("received error from metadata store: %+v", err)
+		return api.StoreResponse{}, err
 	}
 
 	return api.StoreResponse{Gitoid: gid.String()}, nil


### PR DESCRIPTION
## What this PR does / why we need it

Adds protection to the users while storing attestations

As Archivista relies on Object Storage/Filesystem to store the blob attestation and the SQL server to register the attestations for querying using GraphSQL, the flow needs to be consistent, as the services can fail.

Ideally, the Store should happen transactional and not finish with inconsistency: file available in the SQL but not in the metadata Storage, for example. If it happens, the user will query the SQL but will not be able to retrieve/download the attestation blob.

A minor fix is done in this PR, first adding the to the metadata storage and after registering in the SQL server.
So, if the metadata storage fails, it will not continue and save it in the SQL server.

## Acceptance Criteria Met

- [x] Docs changes if needed
- [x] Testing changes if needed
- [x] All workflow checks passing (automatically enforced)
- [x] All review conversations resolved (automatically enforced)
- [x] [DCO Sign-off](https://github.com/apps/dco)

**Special notes for your reviewer**:

None