### PR TITLE
Fix api responses

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -44,6 +44,21 @@ const docTemplate = `{
                         "schema": {
                             "$ref": "#/definitions/dsse.Envelope"
                         }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found"
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
                     }
                 }
             }
@@ -90,6 +105,21 @@ const docTemplate = `{
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/dsse.Envelope"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found"
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
                         }
                     }
                 }

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -21,14 +21,23 @@ const docTemplate = `{
     "host": "{{.Host}}",
     "basePath": "{{.BasePath}}",
     "paths": {
-        "/donwload/{gitoid}": {
-            "post": {
+        "/download/{gitoid}": {
+            "get": {
                 "description": "download an attestation",
                 "produces": [
                     "application/json"
                 ],
                 "summary": "Download",
                 "deprecated": true,
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "gitoid",
+                        "name": "gitoid",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -45,7 +54,7 @@ const docTemplate = `{
                 "produces": [
                     "application/json"
                 ],
-                "summary": "Store",
+                "summary": "Upload",
                 "deprecated": true,
                 "responses": {
                     "200": {
@@ -57,8 +66,8 @@ const docTemplate = `{
                 }
             }
         },
-        "/v1/donwload/{gitoid}": {
-            "post": {
+        "/v1/download/{gitoid}": {
+            "get": {
                 "description": "download an attestation",
                 "produces": [
                     "application/json"
@@ -67,6 +76,15 @@ const docTemplate = `{
                     "attestation"
                 ],
                 "summary": "Download",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "gitoid",
+                        "name": "gitoid",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -106,7 +124,7 @@ const docTemplate = `{
                 "tags": [
                     "attestation"
                 ],
-                "summary": "Store",
+                "summary": "Upload",
                 "responses": {
                     "200": {
                         "description": "OK",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -36,6 +36,21 @@
                         "schema": {
                             "$ref": "#/definitions/dsse.Envelope"
                         }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found"
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
                     }
                 }
             }
@@ -82,6 +97,21 @@
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/dsse.Envelope"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found"
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
                         }
                     }
                 }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -13,14 +13,23 @@
         "version": "v1"
     },
     "paths": {
-        "/donwload/{gitoid}": {
-            "post": {
+        "/download/{gitoid}": {
+            "get": {
                 "description": "download an attestation",
                 "produces": [
                     "application/json"
                 ],
                 "summary": "Download",
                 "deprecated": true,
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "gitoid",
+                        "name": "gitoid",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -37,7 +46,7 @@
                 "produces": [
                     "application/json"
                 ],
-                "summary": "Store",
+                "summary": "Upload",
                 "deprecated": true,
                 "responses": {
                     "200": {
@@ -49,8 +58,8 @@
                 }
             }
         },
-        "/v1/donwload/{gitoid}": {
-            "post": {
+        "/v1/download/{gitoid}": {
+            "get": {
                 "description": "download an attestation",
                 "produces": [
                     "application/json"
@@ -59,6 +68,15 @@
                     "attestation"
                 ],
                 "summary": "Download",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "gitoid",
+                        "name": "gitoid",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -98,7 +116,7 @@
                 "tags": [
                     "attestation"
                 ],
-                "summary": "Store",
+                "summary": "Upload",
                 "responses": {
                     "200": {
                         "description": "OK",

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -67,10 +67,16 @@ info:
   title: Archivista API
   version: v1
 paths:
-  /donwload/{gitoid}:
-    post:
+  /download/{gitoid}:
+    get:
       deprecated: true
       description: download an attestation
+      parameters:
+      - description: gitoid
+        in: path
+        name: gitoid
+        required: true
+        type: string
       produces:
       - application/json
       responses:
@@ -90,10 +96,16 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/api.StoreResponse'
-      summary: Store
-  /v1/donwload/{gitoid}:
-    post:
+      summary: Upload
+  /v1/download/{gitoid}:
+    get:
       description: download an attestation
+      parameters:
+      - description: gitoid
+        in: path
+        name: gitoid
+        required: true
+        type: string
       produces:
       - application/json
       responses:
@@ -127,7 +139,7 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/api.StoreResponse'
-      summary: Store
+      summary: Upload
       tags:
       - attestation
 swagger: "2.0"

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -84,6 +84,16 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/dsse.Envelope'
+        "400":
+          description: Bad Request
+          schema:
+            type: string
+        "404":
+          description: Not Found
+        "500":
+          description: Internal Server Error
+          schema:
+            type: string
       summary: Download
   /upload:
     post:
@@ -113,6 +123,16 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/dsse.Envelope'
+        "400":
+          description: Bad Request
+          schema:
+            type: string
+        "404":
+          description: Not Found
+        "500":
+          description: Internal Server Error
+          schema:
+            type: string
       summary: Download
       tags:
       - attestation

--- a/entrypoint-dev.sh
+++ b/entrypoint-dev.sh
@@ -44,4 +44,4 @@ if [[ $atlas_rc -ne 0 ]]; then
     exit 1
 fi
 
-CompileDaemon -log-prefix=false -build="go build -o /out/archivista ./cmd/archivista" -command="/out/archivista"
+CompileDaemon -log-prefix=false -build="go build -buildvcs=false -o /out/archivista ./cmd/archivista" -command="/out/archivista"

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -160,9 +160,10 @@ func (s *Server) UploadHandler(w http.ResponseWriter, r *http.Request) {
 // @Summary Download
 // @Description download an attestation
 // @Produce  json
+// @Param gitoid path string true "gitoid"
 // @Success 200 {object} dsse.Envelope
 // @Tags attestation
-// @Router /v1/download/{gitoid} [post]
+// @Router /v1/download/{gitoid} [get]
 func (s *Server) Download(ctx context.Context, gitoid string) (io.ReadCloser, error) {
 	if len(strings.TrimSpace(gitoid)) == 0 {
 		return nil, errors.New("gitoid parameter is required")
@@ -183,9 +184,10 @@ func (s *Server) Download(ctx context.Context, gitoid string) (io.ReadCloser, er
 // @Summary Download
 // @Description download an attestation
 // @Produce  json
+// @Param gitoid path string true "gitoid"
 // @Success 200 {object} dsse.Envelope
 // @Deprecated
-// @Router /download/{gitoid} [post]
+// @Router /download/{gitoid} [get]
 func (s *Server) DownloadHandler(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		http.Error(w, fmt.Sprintf("%s is an unsupported method", r.Method), http.StatusBadRequest)


### PR DESCRIPTION
## What this PR does / why we need it

Minor fix for the development environment, disabling vcs (`-disablevcs`)

- Fix the correct method for /api/v1/download as GET instead POST
- Include the parameter which allows users to try the endpoint directly
  from swagger documentation

Archivista Download API returned 500 if a GitOID is available while
the user calls the `/v1/download/<gitoid>` (`/download/<gitoid>`)
endpoint.

It is not an Internal Server Error (500) but a not-found for the
GitOID endpoint.

Update Swagger documentation.

## Acceptance Criteria Met

- [x] Docs changes if needed
- [x] Testing changes if needed
- [ ] All workflow checks passing (automatically enforced)
- [ ] All review conversations resolved (automatically enforced)
- [x] [DCO Sign-off](https://github.com/apps/dco)
