### PR TITLE
feat: Implement plugin system for archivists' parsers

### DIFF
--- a/pkg/metadatastorage/attestationcollection/parser_registry.go
+++ b/pkg/metadatastorage/attestationcollection/parser_registry.go
@@ -1,0 +1,35 @@
+// Copyright 2024 The Archivista Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package attestationcollection
+
+import (
+	"context"
+	"encoding/json"
+	"github.com/in-toto/archivista/ent"
+	"log"
+)
+
+var registeredParsers map[string]AttestationParser
+
+func init() {
+	registeredParsers = make(map[string]AttestationParser)
+}
+
+func Register(attestationType string, parser AttestationParser) {
+	registeredParsers[attestationType] = parser
+	log.Printf("parser registered: %s", attestationType)
+}
+
+type AttestationParser func(ctx context.Context, tx *ent.Tx, attestation *ent.Attestation, attestationType string, message json.RawMessage) error

--- a/pkg/metadatastorage/attestationcollection/parser_registry_test.go
+++ b/pkg/metadatastorage/attestationcollection/parser_registry_test.go
@@ -1,0 +1,40 @@
+// Copyright 2024 The Archivista Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package attestationcollection
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/in-toto/archivista/ent"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRegister(t *testing.T) {
+	// Define a mock parser function
+	mockParser := func(ctx context.Context, tx *ent.Tx, attestation *ent.Attestation, attestationType string, message json.RawMessage) error {
+		return nil
+	}
+
+	// Register the mock parser
+	Register("mockType", mockParser)
+
+	// Check if the parser is registered
+	registeredParser, exists := registeredParsers["mockType"]
+	var typedParser AttestationParser = mockParser
+	assert.True(t, exists, "Parser should be registered")
+	assert.IsType(t, typedParser, registeredParser, "Registered parser should match the mock parser")
+}


### PR DESCRIPTION
This commit introduces a flexible plugin system for archivists' parsers,
allowing new parsers to be registered dynamically. The system utilizes an
initialization function that registers parsers via a `Register` function. The
primary changes include:

- Creation of `parser_registry.go` to handle parser registration and storage.
- Modification of `parserstorer.go` to integrate the new parser registration
  system and utilize registered parsers during attestation storage.

This system enhances the extensibility of the parser functionality and improves
maintainability by decoupling the parser registration from the core logic.

Changes:
- Added `internal/metadatastorage/attestationcollection/parser_registry.go` for
  parser registration.
- Updated `internal/metadatastorage/attestationcollection/parserstorer.go` to
  support the new plugin system.

Signed-off-by: Frederick F. Kautz IV <frederick@testifysec.com>
