### PR TITLE
chore(ci): build images with dockerfile instead of ko

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -86,6 +86,12 @@ jobs:
                 username: ${{ github.actor }}
                 password: ${{ secrets.GITHUB_TOKEN }}
 
+            - name: Set up QEMU
+              uses: docker/setup-qemu-action@v3
+
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v3
+                        
             - name: Download GoReleaser
               run: go install github.com/goreleaser/goreleaser@v1.23.0
 

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -96,11 +96,12 @@ jobs:
               run: go install github.com/goreleaser/goreleaser@v1.23.0
 
             - name: Run GoReleaser
-              uses: testifysec/witness-run-action@85ddab8b46a86b2905a3b547a1806ab264fbb810
+              uses: testifysec/witness-run-action@cceed291062b350dc658d7d189933ac47d4f4dec
               env:
                 GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                 GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
               with:
+                witness-install-dir: /opt/witness
                 step: "build"
                 attestations: "github"
                 command: goreleaser release --clean

--- a/.github/workflows/witness.yml
+++ b/.github/workflows/witness.yml
@@ -49,8 +49,9 @@ jobs:
               go-version: 1.21.x
 
           - if: ${{ inputs.pull_request == false }}
-            uses: testifysec/witness-run-action@85ddab8b46a86b2905a3b547a1806ab264fbb810
+            uses: testifysec/witness-run-action@cceed291062b350dc658d7d189933ac47d4f4dec
             with:
+              witness-install-dir: /opt/witness
               step: ${{ inputs.step }}
               attestations: ${{ inputs.attestations }}
               command: /bin/sh -c "${{ inputs.command }}"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -74,18 +74,56 @@ release:
   prerelease: auto
   github:
     owner: "{{ .Env.GITHUB_REPOSITORY_OWNER }}"
+dockers:
+  - image_templates:
+    - "ghcr.io/in-toto/archivista:{{ .Version }}-amd64"
+    use: buildx
+    build_flag_templates:
+      - "--pull"
+      - "--platform=linux/amd64"
+    extra_files:
+      - "archivista.graphql"
+      - "ent.graphql"
+      - "ent.resolvers.go"
+      - "entrypoint.sh"
+      - "gen.go"
+      - "generated.go"
+      - "go.mod"
+      - "go.sum"
+      - "resolver.go"
+      - "docs"
+      - "ent"
+      - "cmd"
+      - "ent"
+      - "pkg"
+  - image_templates:
+    - "ghcr.io/in-toto/archivista:{{ .Version }}-arm64"
+    use: buildx
+    build_flag_templates:
+      - "--pull"
+      - "--platform=linux/arm64"
+    extra_files:
+      - "archivista.graphql"
+      - "ent.graphql"
+      - "ent.resolvers.go"
+      - "entrypoint.sh"
+      - "gen.go"
+      - "generated.go"
+      - "go.mod"
+      - "go.sum"
+      - "resolver.go"
+      - "docs"
+      - "ent"
+      - "cmd"
+      - "ent"
+      - "pkg"
+    goarch: arm64
+docker_manifests:
+  - name_template: "ghcr.io/in-toto/archivista:{{ .Version }}"
+    image_templates:
+      - "ghcr.io/in-toto/archivista:{{ .Version }}-amd64"
+      - "ghcr.io/in-toto/archivista:{{ .Version }}-arm64"
 kos:
-  - repository: ghcr.io/in-toto/archivista
-    id: archivista
-    build: archivista
-    tags:
-    - '{{.Version}}'
-    bare: true
-    preserve_import_paths: false
-    creation_time: '{{.CommitTimestamp}}'
-    platforms:
-    - linux/amd64
-    - linux/arm64
   - repository: ghcr.io/in-toto/archivistactl
     id: archivistactl
     build: archivistactl


### PR DESCRIPTION
Our Dockerfile includes our migrations and Atlas to execute those migrations. However, the public image we are pushing is built with Ko and excludes these files/tools. This commit switches gorelease to build the image with the included Dockerfile.

## What this PR does / why we need it

Description

## Which issue(s) this PR fixes (optional)

(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*

Fixes #

## Acceptance Criteria Met

- [ ] Docs changes if needed
- [ ] Testing changes if needed
- [ ] All workflow checks passing (automatically enforced)
- [ ] All review conversations resolved (automatically enforced)
- [ ] [DCO Sign-off](https://github.com/apps/dco)

**Special notes for your reviewer**: