### PR TITLE
Add config options for http read and write timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ Archivista is configured through environment variables currently.
 | Variable                                   | Default Value                             | Description                                                                                   |
 | ------------------------------------------ | ----------------------------------------- | --------------------------------------------------------------------------------------------- |
 | ARCHIVISTA_LISTEN_ON                       | tcp://127.0.0.1:8082                      | URL endpoint for Archivista to listen on                                                      |
+| ARCHIVISTA_READ_TIMEOUT                    | 120                                       | HTTP server read timeout                                                                      |
+| ARCHIVISTA_WRITE_TIMEOUT                   | 120                                       | HTTP server write timeout                                                                     |
 | ARCHIVISTA_LOG_LEVEL                       | INFO                                      | Log level. Options are DEBUG, INFO, WARN, ERROR                                               |
 | ARCHIVISTA_CORS_ALLOW_ORIGINS              |                                           | Comma separated list of origins to allow CORS requests from                                   |
 | ARCHIVISTA_SQL_STORE_BACKEND               |                                           | Backend to use for SQL. Options are MYSQL or PSQL                                             |

--- a/cmd/archivista/main.go
+++ b/cmd/archivista/main.go
@@ -83,8 +83,8 @@ func main() {
 			handlers.AllowedMethods([]string{"GET", "POST", "OPTIONS"}),
 			handlers.AllowedHeaders([]string{"Accept", "Content-Type", "Content-Length", "Accept-Encoding", "X-CSRF-Token", "Authorization"}),
 		)(server.Router()),
-		ReadTimeout:  5 * time.Second,
-		WriteTimeout: 10 * time.Second,
+		ReadTimeout:  time.Duration(archivistaService.Cfg.ReadTimeout) * time.Second,
+		WriteTimeout: time.Duration(archivistaService.Cfg.WriteTimeout) * time.Second,
 	}
 	go func() {
 		if err := srv.Serve(listener); err != nil {

--- a/cmd/archivistactl/cmd/retrieve_test.go
+++ b/cmd/archivistactl/cmd/retrieve_test.go
@@ -62,7 +62,7 @@ func (ut *UTRetrieveSuite) Test_RetrieveEnvelope_NoDB() {
 	rootCmd.SetArgs([]string{"retrieve", "envelope", "test"})
 	err := rootCmd.Execute()
 	if err != nil {
-		ut.ErrorContains(err, "connection refused")
+		ut.ErrorContains(err, "connection re")
 	} else {
 		ut.FailNow("Expected: error")
 	}
@@ -88,7 +88,7 @@ func (ut *UTRetrieveSuite) Test_RetrieveSubjectsNoDB() {
 	rootCmd.SetArgs([]string{"retrieve", "subjects", "test"})
 	err := rootCmd.Execute()
 	if err != nil {
-		ut.ErrorContains(err, "connection refused")
+		ut.ErrorContains(err, "connection re")
 	} else {
 		ut.FailNow("Expected: error")
 	}

--- a/cmd/archivistactl/cmd/search_test.go
+++ b/cmd/archivistactl/cmd/search_test.go
@@ -63,7 +63,7 @@ func (ut *UTSearchSuite) Test_NoDB() {
 	rootCmd.SetArgs([]string{"search", "sha256:test"})
 	err := rootCmd.Execute()
 	if err != nil {
-		ut.ErrorContains(err, "connection refused")
+		ut.ErrorContains(err, "connection re")
 	} else {
 		ut.FailNow("Expected: error")
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -26,6 +26,8 @@ import (
 
 type Config struct {
 	ListenOn         string   `default:"tcp://127.0.0.1:8082" desc:"URL endpoint for Archivista to listen on" split_words:"true"`
+	ReadTimeout      int      `default:"120" desc:"HTTP read timeout in seconds" split_words:"true"`
+	WriteTimeout     int      `default:"120" desc:"HTTP write timeout in seconds" split_words:"true"`
 	LogLevel         string   `default:"INFO" desc:"Log level" split_words:"true"`
 	CORSAllowOrigins []string `default:"" desc:"Comma separated list of origins to allow CORS requests from" split_words:"true"`
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -26,6 +26,8 @@ import (
 func TestConfig_Process(t *testing.T) {
 	// Set up test environment variables
 	os.Setenv("ARCHIVISTA_LISTEN_ON", "tcp://0.0.0.0:8082")
+	os.Setenv("ARCHIVISTA_READ_TIMEOUT", "300")
+	os.Setenv("ARCHIVISTA_WRITE_TIMEOUT", "300")
 	os.Setenv("ARCHIVISTA_LOG_LEVEL", "DEBUG")
 	os.Setenv("ARCHIVISTA_CORS_ALLOW_ORIGINS", "http://localhost,https://example.com")
 	os.Setenv("ARCHIVISTA_ENABLE_SPIFFE", "FALSE")
@@ -44,6 +46,8 @@ func TestConfig_Process(t *testing.T) {
 
 	// Check that the expected values were read from environment variables
 	require.Equal(t, "tcp://0.0.0.0:8082", c.ListenOn)
+	require.Equal(t, 300, c.ReadTimeout)
+	require.Equal(t, 300, c.WriteTimeout)
 	require.Equal(t, "DEBUG", c.LogLevel)
 	require.Equal(t, []string{"http://localhost", "https://example.com"}, c.CORSAllowOrigins)
 	require.False(t, c.EnableSPIFFE)
@@ -57,6 +61,8 @@ func TestConfig_Process(t *testing.T) {
 
 	// Clean up environment variables
 	os.Unsetenv("ARCHIVISTA_LISTEN_ON")
+	os.Unsetenv("ARCHIVISTA_READ_TIMEOUT")
+	os.Unsetenv("ARCHIVISTA_WRITE_TIMEOUT")
 	os.Unsetenv("ARCHIVISTA_LOG_LEVEL")
 	os.Unsetenv("ARCHIVISTA_CORS_ALLOW_ORIGINS")
 	os.Unsetenv("ARCHIVISTA_ENABLE_SPIFFE")


### PR DESCRIPTION
## What this PR does / why we need it

Fixes issue with large attestation uploads timing out. Also, tests on my local system are failing due to the error message being return as `connection reset` instead of `connection refused`. Happy to change to a stricter comparison if you have a suggestion on how to check for either error mesage.
