### PR TITLE
fix: golangci-lint warning (v1.60.x)

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -465,7 +465,7 @@ func (s *Server) DownloadArtifactHandler(w http.ResponseWriter, r *http.Request)
 
 	defer func() {
 		if err := file.Close(); err != nil {
-			logrus.Errorf(fmt.Sprintf("failed to close artifact distribution file %s: %+v", distro.FileLocation, err))
+			logrus.Errorf("failed to close artifact distribution file %s: %+v", distro.FileLocation, err)
 		}
 	}()
 


### PR DESCRIPTION

## What this PR does / why we need it

Error: pkg/server/server.go:468:18: printf: non-constant format string in call to github.com/sirupsen/logrus.Errorf (govet)
logrus.Errorf(fmt.Sprintf("failed to close artifact distribution file %s: %+v", distro.FileLocation, err))

## Acceptance Criteria Met

- [ ] Docs changes if needed
- [ ] Testing changes if needed
- [ ] All workflow checks passing (automatically enforced)
- [ ] All review conversations resolved (automatically enforced)
- [x] [DCO Sign-off](https://github.com/apps/dco)

**Special notes for your reviewer**: