### PR TITLE
Update pre-commit-config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,11 +14,11 @@
 
 repos:
 - repo: https://github.com/gitleaks/gitleaks
-  rev: v8.18.2
+  rev: v8.18.4
   hooks:
   - id: gitleaks
 - repo: https://github.com/golangci/golangci-lint
-  rev: v1.56.2
+  rev: v1.60.3
   hooks:
   - id: golangci-lint
 - repo: https://github.com/jumanjihouse/pre-commit-hooks
@@ -26,7 +26,7 @@ repos:
   hooks:
   - id: shellcheck
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.5.0
+  rev: v4.6.0
   hooks:
   - id: end-of-file-fixer
   - id: trailing-whitespace


### PR DESCRIPTION
## What this PR does / why we need it

golang-ci-lint was breaking with `go 1.23`