### PR TITLE
fix: explicitly set serviceAccountName in deployment podspec

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -52,3 +52,4 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      serviceAccountName: {{ include "archivista.serviceAccountName" . }}


### PR DESCRIPTION
## What this PR does / why we need it

This uses the existing `archivista.serviceAccountName` from helpers to explicitly set the `serviceAccountName` for pods. Without this change the pods still use the `default` service account even if a different service account is created by the helm chart when `serviceAccount.create` is true.

## Which issue(s) this PR fixes (optional)

Fixes #370 

## Acceptance Criteria Met

- [ ] Docs changes if needed
- [ ] Testing changes if needed
- [ ] All workflow checks passing (automatically enforced)
- [ ] All review conversations resolved (automatically enforced)
- [ ] [DCO Sign-off](https://github.com/apps/dco)

**Special notes for your reviewer**: