### PR TITLE
release archivista charts  0.5.0

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -17,7 +17,7 @@ name: archivista
 description: A Helm chart for Archivista
 
 type: application
-version: 0.4.0
+version: 0.5.0
 
 keywords:
   - attestation
@@ -31,4 +31,4 @@ sources:
 maintainers:
   - name: in-toto
 
-appVersion: "0.4.0"
+appVersion: "0.5.3"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -17,7 +17,7 @@ image:
   repository: ghcr.io/in-toto/archivista
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "0.4.0"
+  tag: "0.5.3"
 
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION

## What this PR does / why we need it

Release Archivista Chart 0.5.0

- update chart 0.5.0 to use latest archivista 0.5.3
