### PR TITLE
Write to a branch requires write permissions to content

### DIFF
--- a/.github/workflows/update-pre-commit-hooks.yml
+++ b/.github/workflows/update-pre-commit-hooks.yml
@@ -28,6 +28,7 @@ jobs:
   update-pre-commit-hooks:
     runs-on: ubuntu-latest
     permissions:
+      contents: write
       pull-requests: write
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683


### PR DESCRIPTION
## What this PR does / why we need it

Fix issue with automated PRs for pre-commit hooks.
