### PR TITLE
fix: flaky filestore test

### DIFF
--- a/pkg/objectstorage/filestore/file_test.go
+++ b/pkg/objectstorage/filestore/file_test.go
@@ -50,7 +50,7 @@ func (ut *UTFileStoreSuite) TearDownTest() {
 }
 func (ut *UTFileStoreSuite) Test_Get() {
 
-	store, _, err := filestore.New(context.Background(), ut.tempDir, "")
+	store, _, err := filestore.New(context.Background(), ut.tempDir, ":50025")
 	if err != nil {
 		ut.FailNow(err.Error())
 	}


### PR DESCRIPTION
fix: use high number port to prevent permissions error or conflicts on default port 80
