### PR TITLE
fix: use created listener when serving tls

### DIFF
--- a/cmd/archivista/main.go
+++ b/cmd/archivista/main.go
@@ -89,8 +89,8 @@ func main() {
 
 	go func() {
 		if archivistaService.Cfg.EnableTLS {
-			if err := srv.ListenAndServeTLS(archivistaService.Cfg.TLSCert, archivistaService.Cfg.TLSKey); err != nil {
-				logrus.Fatalf("unable to start http serveR: %+v", err)
+			if err := srv.ServeTLS(listener, archivistaService.Cfg.TLSCert, archivistaService.Cfg.TLSKey); err != nil {
+				logrus.Fatalf("unable to start http server: %+v", err)
 			}
 		} else {
 			if err := srv.Serve(listener); err != nil {


### PR DESCRIPTION
## What this PR does / why we need it

Issue was being encountered where configured LISTEN_On address and port were being disregarded when running with TLS enabled. This was happening because we were not using the configured listener.

## Which issue(s) this PR fixes (optional)

(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*

Fixes #

## Acceptance Criteria Met

- [ ] Docs changes if needed
- [ ] Testing changes if needed
- [ ] All workflow checks passing (automatically enforced)
- [ ] All review conversations resolved (automatically enforced)
- [ ] [DCO Sign-off](https://github.com/apps/dco)

**Special notes for your reviewer**: