### PR TITLE
fix(#560): Fix MYSQL Conn string requirements

### DIFF
--- a/pkg/metadatastorage/sqlstore/client.go
+++ b/pkg/metadatastorage/sqlstore/client.go
@@ -16,6 +16,7 @@ package sqlstore
 
 import (
 	"fmt"
+	"net/url"
 	"strings"
 	"time"
 
@@ -57,6 +58,33 @@ func ClientWithConnMaxLifetime(connMaxLifetime time.Duration) ClientOption {
 	}
 }
 
+// ensureMySQLConnectionString ensures the connection string has the tcp protocol as required by the go-sql-driver
+func ensureMySQLConnectionString(connStr string) string {
+	schema := "mysql://"
+
+	if strings.Contains(connStr, "@tcp(") {
+		return connStr
+	}
+
+	// Add mysql:// prefix if not present. URL Parse will fail silently if a schema is not present
+	if !strings.HasPrefix(connStr, schema) {
+		connStr = schema + connStr
+	}
+
+	// Parse the connection string as a URL
+	u, err := url.Parse(connStr)
+	if err != nil {
+		return connStr
+	}
+
+	// Modify the host to include tcp
+	u.Host = "tcp(" + u.Host + ")"
+
+	// Remove the mysql:// prefix from the final string
+	result := strings.TrimPrefix(u.String(), schema)
+	return result
+}
+
 // NewEntClient creates an ent client for use in the sqlmetadata store.
 // Valid backends are MYSQL and PSQL.
 func NewEntClient(sqlBackend string, connectionString string, opts ...ClientOption) (*ent.Client, error) {
@@ -73,6 +101,8 @@ func NewEntClient(sqlBackend string, connectionString string, opts ...ClientOpti
 	var entDialect string
 	switch strings.ToUpper(sqlBackend) {
 	case "MYSQL":
+		// Ensure the connection string has the tcp protocol as required by the go-sql-driver
+		connectionString = ensureMySQLConnectionString(connectionString)
 		dbConfig, err := mysql.ParseDSN(connectionString)
 		if err != nil {
 			return nil, fmt.Errorf("could not parse mysql connection string: %w", err)

--- a/pkg/metadatastorage/sqlstore/client_test.go
+++ b/pkg/metadatastorage/sqlstore/client_test.go
@@ -1,0 +1,61 @@
+package sqlstore
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnsureMySQLConnectionString(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		expected    string
+		expectError bool
+	}{
+		{
+			name:        "already has tcp protocol",
+			input:       "user:pass@tcp(localhost:3306)/dbname",
+			expected:    "user:pass@tcp(localhost:3306)/dbname",
+			expectError: false,
+		},
+		{
+			name:        "needs tcp protocol",
+			input:       "user:pass@localhost:3306/dbname",
+			expected:    "user:pass@tcp(localhost:3306)/dbname",
+			expectError: false,
+		},
+		{
+			name:        "with mysql:// prefix",
+			input:       "mysql://user:pass@localhost:3306/dbname",
+			expected:    "user:pass@tcp(localhost:3306)/dbname",
+			expectError: false,
+		},
+		{
+			name:        "invalid url format",
+			input:       "invalid:url:format",
+			expected:    "",
+			expectError: true,
+		},
+		{
+			name:        "with query parameters",
+			input:       "user:pass@localhost:3306/dbname?param=value",
+			expected:    "user:pass@tcp(localhost:3306)/dbname?param=value",
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := ensureMySQLConnectionString(tt.input)
+			if tt.expectError {
+				require.Error(t, err)
+				assert.Empty(t, result)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expected, result)
+			}
+		})
+	}
+}

--- a/pkg/metadatastorage/sqlstore/client_test.go
+++ b/pkg/metadatastorage/sqlstore/client_test.go
@@ -1,3 +1,17 @@
+// Copyright 2025 The Archivista Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package sqlstore
 
 import (


### PR DESCRIPTION
## What this PR does / why we need it

This adds a function to ensure the connection string has tcp() wrapped around host part. This is required by the go-sql-driver but not required by atlas for DB migration,

## Which issue(s) this PR fixes (optional)
(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*

Fixes #560 

## Acceptance Criteria Met

- [ ] Docs changes if needed
- [ ] Testing changes if needed
- [ ] All workflow checks passing (automatically enforced)
- [ ] All review conversations resolved (automatically enforced)
- [ ] [DCO Sign-off](https://github.com/apps/dco)

**Special notes for your reviewer**: