### PR TITLE
fix: mysql conn string requirement

### DIFF
--- a/pkg/metadatastorage/sqlstore/client.go
+++ b/pkg/metadatastorage/sqlstore/client.go
@@ -16,6 +16,7 @@ package sqlstore
 
 import (
 	"fmt"
+	"net/url"
 	"strings"
 	"time"
 
@@ -57,6 +58,33 @@ func ClientWithConnMaxLifetime(connMaxLifetime time.Duration) ClientOption {
 	}
 }
 
+// ensureMySQLConnectionString ensures the connection string has the tcp protocol as required by the go-sql-driver
+func ensureMySQLConnectionString(connStr string) (string, error) {
+	schema := "mysql://"
+
+	if strings.Contains(connStr, "@tcp(") {
+		return connStr, nil
+	}
+
+	// Add mysql:// prefix if not present. URL Parse will fail silently if a schema is not present
+	if !strings.HasPrefix(connStr, schema) {
+		connStr = schema + connStr
+	}
+
+	// Parse the connection string as a URL
+	u, err := url.Parse(connStr)
+	if err != nil {
+		return "", fmt.Errorf("invalid mysql connection string: %w", err)
+	}
+
+	// Modify the host to include tcp
+	u.Host = "tcp(" + u.Host + ")"
+
+	// Remove the mysql:// prefix from the final string
+	result := strings.TrimPrefix(u.String(), schema)
+	return result, nil
+}
+
 // NewEntClient creates an ent client for use in the sqlmetadata store.
 // Valid backends are MYSQL and PSQL.
 func NewEntClient(sqlBackend string, connectionString string, opts ...ClientOption) (*ent.Client, error) {
@@ -73,6 +101,12 @@ func NewEntClient(sqlBackend string, connectionString string, opts ...ClientOpti
 	var entDialect string
 	upperSqlBackend := strings.ToUpper(sqlBackend)
 	if strings.HasPrefix(upperSqlBackend, "MYSQL") {
+		// Ensure the connection string has the tcp protocol as required by the go-sql-driver
+		var err error
+		connectionString, err = ensureMySQLConnectionString(connectionString)
+		if err != nil {
+			return nil, fmt.Errorf("could not ensure mysql connection string: %w", err)
+		}
 		dbConfig, err := mysql.ParseDSN(connectionString)
 		if err != nil {
 			return nil, fmt.Errorf("could not parse mysql connection string: %w", err)

--- a/pkg/metadatastorage/sqlstore/client_test.go
+++ b/pkg/metadatastorage/sqlstore/client_test.go
@@ -1,0 +1,112 @@
+// Copyright 2025 The Archivista Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sqlstore
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewEntClient_MySQLConnectionStringError(t *testing.T) {
+	tests := []struct {
+		name             string
+		sqlBackend       string
+		connectionString string
+	}{
+		{
+			name:             "mysql with invalid URL that breaks url.Parse",
+			sqlBackend:       "MYSQL",
+			connectionString: "user:pa%zzss@localhost:3306/dbname", // Invalid percent encoding
+		},
+		{
+			name:             "mysql with control characters",
+			sqlBackend:       "mysql",
+			connectionString: "user:pass@local\x00host:3306/dbname", // Null byte in URL
+		},
+		{
+			name:             "mysql with invalid hex escape",
+			sqlBackend:       "MYSQL",
+			connectionString: "user:pass%ZZword@localhost:3306/db", // Invalid hex in percent encoding
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// This should trigger an error in ensureMySQLConnectionString
+			// which will cover lines 104-109
+			client, err := NewEntClient(tt.sqlBackend, tt.connectionString)
+
+			require.Error(t, err)
+			assert.Nil(t, client)
+			assert.Contains(t, err.Error(), "could not ensure mysql connection string")
+		})
+	}
+}
+
+func TestEnsureMySQLConnectionString(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		expected    string
+		expectError bool
+	}{
+		{
+			name:        "already has tcp protocol",
+			input:       "user:pass@tcp(localhost:3306)/dbname",
+			expected:    "user:pass@tcp(localhost:3306)/dbname",
+			expectError: false,
+		},
+		{
+			name:        "needs tcp protocol",
+			input:       "user:pass@localhost:3306/dbname",
+			expected:    "user:pass@tcp(localhost:3306)/dbname",
+			expectError: false,
+		},
+		{
+			name:        "with mysql:// prefix",
+			input:       "mysql://user:pass@localhost:3306/dbname",
+			expected:    "user:pass@tcp(localhost:3306)/dbname",
+			expectError: false,
+		},
+		{
+			name:        "invalid url format",
+			input:       "invalid:url:format",
+			expected:    "",
+			expectError: true,
+		},
+		{
+			name:        "with query parameters",
+			input:       "user:pass@localhost:3306/dbname?param=value",
+			expected:    "user:pass@tcp(localhost:3306)/dbname?param=value",
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := ensureMySQLConnectionString(tt.input)
+			if tt.expectError {
+				require.Error(t, err)
+				assert.Empty(t, result)
+				assert.Contains(t, err.Error(), "invalid mysql connection string")
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expected, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What this PR does / why we need it

Description

This adds a function to ensure the connection string has tcp() wrapped around host part. This is required by the go-sql-driver but not required by atlas for DB migration,
From the pr - fix(#560): Fix MYSQL Conn string requirements #565
I added additional test to it


Fixes #560

## Acceptance Criteria Met

- [ ] Docs changes if needed
- [x] Testing changes if needed
- [ ] All workflow checks passing (automatically enforced)
- [ ] All review conversations resolved (automatically enforced)
- [x] [DCO Sign-off](https://github.com/apps/dco)

**Special notes for your reviewer**: