### PR TITLE
fix the server.go path in Makefile (for swagger docs)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ lint:  ## Run linter
 .PHONY: docs
 docs:  ## Generate swagger docs
 	@go install github.com/swaggo/swag/cmd/swag@v1.16.2
-	@swag init -o docs -d internal/server -g server.go -pd
+	@swag init -o docs -d pkg/server -g server.go -pd
 
 .PHONY: db-migrations
 db-migrations:  ## Run the migrations for the database


### PR DESCRIPTION
## What this PR does / why we need it

Description
Generate swagger docs have wrong path for server.go

## Which issue(s) this PR fixes (optional)

(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*

Fixes #

## Acceptance Criteria Met

- [ ] Docs changes if needed
- [ ] Testing changes if needed
- [ ] All workflow checks passing (automatically enforced)
- [ ] All review conversations resolved (automatically enforced)
- [ ] [DCO Sign-off](https://github.com/apps/dco)

**Special notes for your reviewer**: