### PR TITLE
fix(lint): remove unneeded `// +build ignore`

### DIFF
--- a/ent/entc.go
+++ b/ent/entc.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build ignore
-// +build ignore
 
 package main
 


### PR DESCRIPTION
## What this PR does / why we need it

Description

The old Go v1.17-style `+build` directive comments are now flagged as unnecessary because Go v1.17 is no longer supported, and so all currently-supported versions of Go support the modern `go:build` directives instead.


Fixes #

## Acceptance Criteria Met

- [ ] Docs changes if needed
- [ ] Testing changes if needed
- [ ] All workflow checks passing (automatically enforced)
- [ ] All review conversations resolved (automatically enforced)
- [x] [DCO Sign-off](https://github.com/apps/dco)

**Special notes for your reviewer**: