### PR TITLE
fix: remove unneeded +build ignore flag found by govet

### DIFF
--- a/ent/entc.go
+++ b/ent/entc.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build ignore
-// +build ignore
 
 package main
 


### PR DESCRIPTION
## What this PR does / why we need it

Fix `golangci-lint` failures by removing unneeded build flag.