### PR TITLE
fix(ci): save attestations and upload to workflow run instead of sending to archivista

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -13,96 +13,99 @@
 # limitations under the License.
 
 permissions:
-    contents: read  # This is required for actions/checkout
+  contents: read # This is required for actions/checkout
 name: pipeline
 on:
-    push:
-        tags:
-            - v*
-        branches:
-            - main
-    pull_request:
+  push:
+    tags:
+      - v*
+    branches:
+      - main
+  pull_request:
 jobs:
-    fmt:
-        uses: ./.github/workflows/witness.yml
-        permissions:
-          id-token: write # This is required for requesting the JWT
-          contents: read  # This is required for actions/checkout
+  fmt:
+    uses: ./.github/workflows/witness.yml
+    permissions:
+      id-token: write # This is required for requesting the JWT
+      contents: read # This is required for actions/checkout
+    with:
+      pull_request: ${{ github.event_name == 'pull_request' }}
+      step: static-analysis
+      attestations: "github"
+      command: go fmt ./...
+
+  static_analysis:
+    uses: ./.github/workflows/witness.yml
+    permissions:
+      id-token: write # This is required for requesting the JWT
+      contents: read # This is required for actions/checkout
+    with:
+      pull_request: ${{ github.event_name == 'pull_request' }}
+      step: static-analysis
+      attestations: "github"
+      command: go vet ./...
+
+  tests:
+    needs: [fmt, static_analysis]
+    uses: ./.github/workflows/witness.yml
+    permissions:
+      id-token: write # This is required for requesting the JWT
+      contents: read # This is required for actions/checkout
+    with:
+      pull_request: ${{ github.event_name == 'pull_request' }}
+      step: "tests"
+      attestations: "github"
+      command: |
+        make clean
+        make test
+
+  release:
+    needs: tests
+    permissions:
+      id-token: write
+      contents: write
+      packages: write
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
-          pull_request: ${{ github.event_name == 'pull_request' }}
-          step: static-analysis
+          egress-policy: audit
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: "go.mod"
+          cache: false
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      - name: Download GoReleaser
+        run: go install github.com/goreleaser/goreleaser@v1.23.0
+
+      - name: Run GoReleaser
+        uses: testifysec/witness-run-action@7aa15e327829f1f2a523365c564c948d5dde69dd
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
+        with:
+          witness-install-dir: /opt/witness
+          version: 0.9.1
+          step: "build"
           attestations: "github"
-          command: go fmt ./...
-
-    static_analysis:
-        uses: ./.github/workflows/witness.yml
-        permissions:
-          id-token: write # This is required for requesting the JWT
-          contents: read  # This is required for actions/checkout
-        with:
-          pull_request: ${{ github.event_name == 'pull_request' }}
-          step: static-analysis
-          attestations: "github"
-          command: go vet ./...
-
-    tests:
-        needs: [fmt, static_analysis]
-        uses: ./.github/workflows/witness.yml
-        permissions:
-          id-token: write # This is required for requesting the JWT
-          contents: read  # This is required for actions/checkout
-        with:
-            pull_request: ${{ github.event_name == 'pull_request' }}
-            step: "tests"
-            attestations: "github"
-            command: |
-              make clean
-              make test
-
-    release:
-        needs: tests
-        permissions:
-            id-token: write
-            contents: write
-            packages: write
-        runs-on: ubuntu-latest
-        if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
-
-        steps:
-            - name: Harden Runner
-              uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
-              with:
-                egress-policy: audit
-
-            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-            - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-              with:
-                go-version-file: "go.mod"
-
-            - name: Login to GitHub Container Registry
-              uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
-              with:
-                registry: ghcr.io
-                username: ${{ github.actor }}
-                password: ${{ secrets.GITHUB_TOKEN }}
-
-            - name: Set up QEMU
-              uses: docker/setup-qemu-action@v4
-
-            - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@v4
-
-            - name: Download GoReleaser
-              run: go install github.com/goreleaser/goreleaser@v1.23.0
-
-            - name: Run GoReleaser
-              uses: testifysec/witness-run-action@7aa15e327829f1f2a523365c564c948d5dde69dd
-              env:
-                GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
-              with:
-                witness-install-dir: /opt/witness
-                version: 0.9.1
-                step: "build"
-                attestations: "github"
-                command: goreleaser release --clean
+          command: goreleaser release --clean

--- a/.github/workflows/witness.yml
+++ b/.github/workflows/witness.yml
@@ -1,4 +1,4 @@
-# Copyright 2023 The Archivista Contributors
+# Copyright 2023 The Witness Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,52 +13,105 @@
 # limitations under the License.
 
 on:
-    workflow_call:
-        inputs:
-            pull_request:
-                required: true
-                type: boolean
-            command:
-                required: true
-                type: string
-            step:
-                required: true
-                type: string
-            attestations:
-                required: true
-                type: string
+  workflow_call:
+    inputs:
+      pull_request:
+        required: true
+        type: boolean
+      artifact-download:
+        required: false
+        type: string
+      artifact-upload-name:
+        required: false
+        type: string
+      artifact-upload-path:
+        required: false
+        type: string
+      pre-command:
+        required: false
+        type: string
+      command:
+        required: true
+        type: string
+      step:
+        required: true
+        type: string
+      attestations:
+        required: true
+        type: string
 
 permissions:
   contents: read
 
 jobs:
-    witness:
-        runs-on: ubuntu-22.04
-        permissions:
-          contents: read
-          id-token: write
-        steps:
-          - name: Harden Runner
-            uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
-            with:
-              egress-policy: audit
+  witness:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
 
-          - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-          - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-            with:
-              go-version-file: "go.mod"
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: "go.mod"
 
-          - if: ${{ inputs.pull_request == false }}
-            uses: testifysec/witness-run-action@7aa15e327829f1f2a523365c564c948d5dde69dd
-            with:
-              witness-install-dir: /opt/witness
-              version: 0.9.1
-              step: ${{ inputs.step }}
-              attestations: ${{ inputs.attestations }}
-              command: /bin/sh -c "${{ inputs.command }}"
+      - if: ${{ inputs.artifact-download != '' }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ inputs.artifact-download }}
+          path: /tmp
 
-          - if: ${{ inputs.pull_request == true }}
-            run: ${{ inputs.command }}
+      - if: ${{ inputs.pre-command != '' && inputs.pull_request == false }}
+        uses: testifysec/witness-run-action@7aa15e327829f1f2a523365c564c948d5dde69dd
+        with:
+          step: pre-${{ inputs.step }}
+          attestations: ${{ inputs.attestations }}
+          version: 0.11.0
+          outfile: pre-${{ inputs.step }}-attestation.json
+          enable-archivista: false
+          witness-install-dir: /usr/local/bin
+          command: /bin/sh -c "${{ inputs.pre-command }}"
+      - if: ${{ inputs.pre-command != '' && inputs.pull_request == false }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: pre-${{ inputs.step }}-attestation
+          path: pre-${{ inputs.step }}-attestation.json
+      - if: ${{ inputs.pre-command != '' && inputs.pull_request == true }}
+        run: bash -c "${INPUTS_COMMAND}"
+        env:
+          INPUTS_PRE_COMMAND: ${{ inputs.pre-command }}
 
-          - if: ${{ inputs.step == 'tests' }}
-            uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354
+      - if: ${{ inputs.pull_request == false }}
+        uses: testifysec/witness-run-action@7aa15e327829f1f2a523365c564c948d5dde69dd
+        with:
+          step: ${{ inputs.step }}
+          attestations: ${{ inputs.attestations }}
+          version: 0.11.0
+          outfile: ${{ inputs.step }}-attestation.json
+          enable-archivista: false
+          witness-install-dir: /usr/local/bin
+          command: /bin/sh -c "${{ inputs.command }}"
+      - if: ${{ inputs.pull_request == false }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ inputs.step }}-attestation
+          path: ${{ inputs.step }}-attestation.json
+      - if: ${{ inputs.pull_request == true }}
+        run: bash -c "${INPUTS_COMMAND}"
+        env:
+          INPUTS_COMMAND: ${{ inputs.command }}
+
+      - if: ${{ inputs.artifact-upload-path != '' && inputs.artifact-upload-name != ''}}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ inputs.artifact-upload-name }}
+          path: ${{ inputs.artifact-upload-path }}


### PR DESCRIPTION
## What this PR does / why we need it

save attestations and upload to workflow run instead of sending to archivista. we can reenable archivista once a new public instance is available.