### PR TITLE
Parse the MySQL address with net.SplitHostPort

### DIFF
--- a/pkg/metadatastorage/sqlstore/utils.go
+++ b/pkg/metadatastorage/sqlstore/utils.go
@@ -17,6 +17,7 @@ package sqlstore
 import (
 	"context"
 	"fmt"
+	"net"
 	"strconv"
 	"strings"
 
@@ -69,9 +70,18 @@ func ConfigFromMySQL(connectionString string) (c *driver.Config, user, password 
 		return nil, "", "", fmt.Errorf("parsing connection string: %w", err)
 	}
 
-	addr := strings.Split(dbConfig.Addr, ":")
-	dc.Host = addr[0]
-	port, err := strconv.Atoi(addr[1])
+	// ParseDSN only fills in a default port for tcp, so a unix socket DSN leaves
+	// Addr as a bare path with no colon. Splitting on ":" and indexing element 1
+	// panicked on that, and mis-parsed a bracketed IPv6 host.
+	if dbConfig.Net != "tcp" {
+		return nil, "", "", fmt.Errorf("unsupported mysql network %q: only tcp is supported", dbConfig.Net)
+	}
+	host, portStr, err := net.SplitHostPort(dbConfig.Addr)
+	if err != nil {
+		return nil, "", "", fmt.Errorf("could not parse mysql address %q: %w", dbConfig.Addr, err)
+	}
+	dc.Host = host
+	port, err := strconv.Atoi(portStr)
 	if err != nil {
 		return nil, "", "", fmt.Errorf("could not parse mysql port: %w", err)
 	}

--- a/pkg/metadatastorage/sqlstore/utils_test.go
+++ b/pkg/metadatastorage/sqlstore/utils_test.go
@@ -1,0 +1,56 @@
+// Copyright 2025 The Archivista Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sqlstore
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigFromMySQL(t *testing.T) {
+	t.Run("tcp host and port", func(t *testing.T) {
+		c, user, password, err := ConfigFromMySQL("user:pass@tcp(127.0.0.1:3306)/testify")
+		require.NoError(t, err)
+		assert.Equal(t, "127.0.0.1", c.Host)
+		assert.Equal(t, 3306, c.Port)
+		assert.Equal(t, "testify", c.DB)
+		assert.Equal(t, "user", user)
+		assert.Equal(t, "pass", password)
+	})
+
+	t.Run("bracketed IPv6 host", func(t *testing.T) {
+		// Splitting on ":" left Host as "[" and the port empty.
+		c, _, _, err := ConfigFromMySQL("user:pass@tcp([::1]:3306)/testify")
+		require.NoError(t, err)
+		assert.Equal(t, "::1", c.Host)
+		assert.Equal(t, 3306, c.Port)
+	})
+
+	t.Run("unix socket is rejected, not a panic", func(t *testing.T) {
+		// ParseDSN only defaults a port for tcp, so Addr here is a bare path
+		// with no colon at all.
+		_, _, _, err := ConfigFromMySQL("user:pass@unix(/tmp/mysql.sock)/testify")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "only tcp is supported")
+	})
+
+	t.Run("unparseable dsn", func(t *testing.T) {
+		_, _, _, err := ConfigFromMySQL("not a dsn")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "parsing connection string")
+	})
+}


### PR DESCRIPTION
`ConfigFromMySQL` splits `dbConfig.Addr` on `":"` and indexes element 1:

```go
addr := strings.Split(dbConfig.Addr, ":")
dc.Host = addr[0]
port, err := strconv.Atoi(addr[1])
```

go-sql-driver's `ParseDSN` only fills in a default port when `Net` is `"tcp"`. For a unix socket DSN it leaves `Addr` as a bare socket path with no colon, so there is no element 1:

```
user:pass@tcp(127.0.0.1:3306)/testify      -> Host="127.0.0.1" Port=3306
user:pass@unix(/tmp/mysql.sock)/testify    -> PANIC: runtime error: index out of range [1] with length 1
user:pass@tcp([::1]:3306)/testify          -> err=could not parse mysql port: strconv.Atoi: parsing "": invalid syntax
```

Both production callers reach it with the configured connection string, `NewEntClient` in `client.go` and `RewriteConnectionStringForIAM` in `iam.go`, so a socket DSN takes the server down at startup rather than reporting a bad configuration.

The third line is a second, quieter problem from the same split: a bracketed IPv6 host leaves `Host` as `"["` and the port empty.

`net.SplitHostPort` handles both shapes, and a non-tcp network is now an explicit error that says what is supported rather than a panic.

Added `utils_test.go` covering tcp, IPv6, the unix socket, and an unparseable DSN. Without the change the IPv6 and unix cases both fail, the latter by panicking.
